### PR TITLE
Fix {$LINKLIB} directive on Darwin

### DIFF
--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -51,7 +51,7 @@ const
     {$IFDEF DARWIN}
       SDL_LibName = 'libSDL3.dylib';
       {$IFDEF FPC}
-        {$LINKLIB libSDL2}
+        {$LINKLIB libSDL3}
       {$ENDIF}
     {$ELSE}
       {$IFDEF FPC}


### PR DESCRIPTION
On Darwin, we were linking against SDL2, instead of SDL3.