### PR TITLE
Update SDL_hints.inc to v3.2.12

### DIFF
--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -81,7 +81,7 @@ const
 {$I SDL_revision.inc}                     // 3.1.6-prev
 {$I SDL_locale.inc}                       // 3.2.0
 {$I SDL_guid.inc}                         // 3.1.6-prev
-{$I SDL_hints.inc}                        // 3.2.0
+{$I SDL_hints.inc}                        // 3.2.12
 {$I SDL_misc.inc}                         // 3.2.0
 {$I SDL_stdinc.inc}                       // 3.1.6-prev (unfinished)
 {$I SDL_platform.inc}                     // 3.2.0

--- a/units/SDL_hints.inc
+++ b/units/SDL_hints.inc
@@ -2167,6 +2167,28 @@ const
   }
   SDL_HINT_JOYSTICK_ZERO_CENTERED_DEVICES = 'SDL_JOYSTICK_ZERO_CENTERED_DEVICES';
 
+{**
+ * A variable containing a list of devices and their desired number of haptic
+ * (force feedback) enabled axis.
+ *
+ * The format of the string is a comma separated list of USB VID/PID pairs in
+ * hexadecimal form plus the number of desired axes, e.g.
+ *
+ * `0xAAAA/0xBBBB/1,0xCCCC/0xDDDD/3`
+ *
+ * This hint supports a "wildcard" device that will set the number of haptic
+ * axes on all initialized haptic devices which were not defined explicitly in
+ * this hint.
+ *
+ * `0xFFFF/0xFFFF/1`
+ *
+ * This hint should be set before a controller is opened. The number of haptic
+ * axes won't exceed the number of real axes found on the device.
+ *
+ * \since This hint is available since SDL 3.2.5.
+ *}
+  SDL_HINT_JOYSTICK_HAPTIC_AXES = 'SDL_JOYSTICK_HAPTIC_AXES';
+
 {*
  * A variable that controls keycode representation in keyboard events.
  *
@@ -3560,6 +3582,22 @@ const
  * \since This hint is available since SDL 3.2.0.
   }
   SDL_HINT_VIDEO_WIN_D3DCOMPILER = 'SDL_VIDEO_WIN_D3DCOMPILER';
+
+{**
+ * A variable controlling whether SDL should call XSelectInput() to enable
+ * input events on X11 windows wrapped by SDL windows.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Don't call XSelectInput(), assuming the native window code has done
+ *   it already.
+ * - "1": Call XSelectInput() to enable input events. (default)
+ *
+ * This hint should be set before creating a window.
+ *
+ * \since This hint is available since SDL 3.2.10.
+ *}
+  SDL_HINT_VIDEO_X11_EXTERNAL_WINDOW_INPUT = 'SDL_VIDEO_X11_EXTERNAL_WINDOW_INPUT';
 
 {*
  * A variable controlling whether the X11 _NET_WM_BYPASS_COMPOSITOR hint


### PR DESCRIPTION
This commit adds the following symbols missing from `SDL_hints.inc`:
- `SDL_HINT_JOYSTICK_HAPTIC_AXES`
- `SDL_HINT_VIDEO_X11_EXTERNAL_WINDOW_INPUT`