### PR TITLE
Fix {$LINKLIB} directives in addon libraries

### DIFF
--- a/units/SDL3_image.pas
+++ b/units/SDL3_image.pas
@@ -63,7 +63,7 @@ const
     {$IFDEF DARWIN}
       IMG_LibName = 'libSDL3_image.dylib';
       {$IFDEF FPC}
-        {$LINKLIB libSDL3}
+        {$LINKLIB libSDL3_image}
       {$ENDIF}
     {$ELSE}
       {$IFDEF FPC}
@@ -77,7 +77,7 @@ const
   {$IFDEF MACOS}
     IMG_LibName = 'SDL3_image';
     {$IFDEF FPC}
-      {$linklib libSDL3}
+      {$linklib libSDL3_image}
     {$ENDIF}
   {$ENDIF}
 

--- a/units/SDL3_ttf.pas
+++ b/units/SDL3_ttf.pas
@@ -66,7 +66,7 @@ const
   {$IFDEF DARWIN}
     IMG_LibName = 'libSDL3_ttf.dylib';
     {$IFDEF FPC}
-      {$LINKLIB libSDL3}
+      {$LINKLIB libSDL3_ttf}
     {$ENDIF}
   {$ELSE}
     {$IFDEF FPC}
@@ -80,7 +80,7 @@ const
 {$IFDEF MACOS}
   IMG_LibName = 'SDL3_ttf';
   {$IFDEF FPC}
-    {$linklib libSDL3}
+    {$linklib libSDL3_ttf}
   {$ENDIF}
 {$ENDIF}
 


### PR DESCRIPTION
The `${LINKLIB} directives inside `SDL3_image.pas` and `SDL3_ttf.pas` were all instructing the compiler to link against the base SDL3 library, instead of the respective add-on libraries.