### PR TITLE
Convert all cbool occurrences to Boolean

### DIFF
--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -174,38 +174,38 @@ begin
   frect^.h:=cfloat(rect^.h);
 end;
 
-function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): cbool;
+function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean;
 begin
   Result :=
     (p <> nil) and (r <> nil) and (p^.x >= r^.x) and (p^.x < (r^.x + r^.w)) and
     (p^.y >= r^.y) and (p^.y < (r^.y + r^.h));
 end;
 
-function SDL_RectEmpty(const r: PSDL_Rect): cbool;
+function SDL_RectEmpty(const r: PSDL_Rect): Boolean;
 begin
   Result := (r = nil) or (r^.w <= 0) or (r^.h <= 0);
 end;
 
-function SDL_RectsEqual(const a: PSDL_Rect; const b: PSDL_Rect): cbool;
+function SDL_RectsEqual(const a: PSDL_Rect; const b: PSDL_Rect): Boolean;
 begin
   Result := (a <> nil) and (b <> nil) and (a^.x = b^.x) and (a^.y = b^.y) and
     (a^.w = b^.w) and (a^.h = b^.h);
 end;
 
-function SDL_PointInRectFloat(const p: PSDL_FPoint; const r: PSDL_FRect): cbool;
+function SDL_PointInRectFloat(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean;
 begin
   Result :=
     (p <> nil) and (r <> nil) and (p^.x >= r^.x) and (p^.x <= (r^.x + r^.w)) and
     (p^.y >= r^.y) and (p^.y <= (r^.y + r^.h));
 end;
 
-function SDL_RectEmptyFloat(const r: PSDL_FRect): cbool;
+function SDL_RectEmptyFloat(const r: PSDL_FRect): Boolean;
 begin
   Result := (r = nil) or (r^.w < cfloat(0.0)) or (r^.h < cfloat(0.0));
 end;
 
 function SDL_RectsEqualEpsilon(const a: PSDL_Frect; const b: PSDL_FRect;
-  const epsilon: cfloat): cbool;
+  const epsilon: cfloat): Boolean;
 begin
   Result :=
     (a <> nil) and (b <> nil) and ((a = b) or
@@ -215,7 +215,7 @@ begin
     (SDL_fabsf(a^.h - b^.h) <= epsilon)));
 end;
 
-function SDL_RectsEqualFloat(const a: PSDL_FRect; b: PSDL_FRect): cbool;
+function SDL_RectsEqualFloat(const a: PSDL_FRect; b: PSDL_FRect): Boolean;
 begin
   Result := SDL_RectsEqualEpsilon(a, b, SDL_FLT_EPSILON);
 end;
@@ -336,7 +336,7 @@ begin
   SDL_AtomicIncRef:=SDL_AddAtomicInt(a,1);
 end;
 
-function SDL_AtomicDecRef(a: PSDL_AtomicInt): cbool;
+function SDL_AtomicDecRef(a: PSDL_AtomicInt): Boolean;
 begin
   SDL_AtomicDecRef:=(SDL_AddAtomicInt(a,-1)=1);
 end;

--- a/units/SDL3_image.pas
+++ b/units/SDL3_image.pas
@@ -170,7 +170,7 @@ function IMG_Version: cint; cdecl;
  * \sa IMG_Load_IO
  * \sa SDL_DestroySurface
   }
-function IMG_LoadTyped_IO(src: PSDL_IOStream; closeio: cbool; type_: PAnsiChar): PSDL_Surface; cdecl;
+function IMG_LoadTyped_IO(src: PSDL_IOStream; closeio: Boolean; type_: PAnsiChar): PSDL_Surface; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_LoadTyped_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -271,7 +271,7 @@ function IMG_Load(file_: PAnsiChar): PSDL_Surface; cdecl;
  * \sa IMG_LoadTyped_IO
  * \sa SDL_DestroySurface
   }
-function IMG_Load_IO(src: PSDL_IOStream; closeio: cbool): PSDL_Surface; cdecl;
+function IMG_Load_IO(src: PSDL_IOStream; closeio: Boolean): PSDL_Surface; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_Load_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -355,7 +355,7 @@ function IMG_LoadTexture(renderer: PSDL_Renderer; file_: PAnsiChar): PSDL_Textur
  * \sa IMG_LoadTextureTyped_IO
  * \sa SDL_DestroyTexture
   }
-function IMG_LoadTexture_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; closeio: cbool): PSDL_Texture; cdecl;
+function IMG_LoadTexture_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; closeio: Boolean): PSDL_Texture; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_LoadTexture_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -411,7 +411,7 @@ function IMG_LoadTexture_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; closeio
  * \sa IMG_LoadTexture_IO
  * \sa SDL_DestroyTexture
   }
-function IMG_LoadTextureTyped_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; closeio: cbool; type_: PAnsiChar): PSDL_Texture; cdecl;
+function IMG_LoadTextureTyped_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; closeio: Boolean; type_: PAnsiChar): PSDL_Texture; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_LoadTextureTyped_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -456,7 +456,7 @@ function IMG_LoadTextureTyped_IO(renderer: PSDL_Renderer; src: PSDL_IOStream; cl
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isAVIF(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isAVIF(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isAVIF' {$ENDIF} {$ENDIF};
 
 {*
@@ -500,7 +500,7 @@ function IMG_isAVIF(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isICO(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isICO(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isICO' {$ENDIF} {$ENDIF};
 
 {*
@@ -544,7 +544,7 @@ function IMG_isICO(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isCUR(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isCUR(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isCUR' {$ENDIF} {$ENDIF};
 
 {*
@@ -588,7 +588,7 @@ function IMG_isCUR(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isBMP(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isBMP(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isBMP' {$ENDIF} {$ENDIF};
 
 {*
@@ -632,7 +632,7 @@ function IMG_isBMP(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isGIF(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isGIF(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isGIF' {$ENDIF} {$ENDIF};
 
 {*
@@ -676,7 +676,7 @@ function IMG_isGIF(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isJPG(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isJPG(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isJPG' {$ENDIF} {$ENDIF};
 
 {*
@@ -720,7 +720,7 @@ function IMG_isJPG(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isJXL(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isJXL(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isJXL' {$ENDIF} {$ENDIF};
 
 {*
@@ -764,7 +764,7 @@ function IMG_isJXL(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isLBM(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isLBM(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isLBM' {$ENDIF} {$ENDIF};
 
 {*
@@ -808,7 +808,7 @@ function IMG_isLBM(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isPCX(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isPCX(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isPCX' {$ENDIF} {$ENDIF};
 
 {*
@@ -852,7 +852,7 @@ function IMG_isPCX(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isPNG(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isPNG(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isPNG' {$ENDIF} {$ENDIF};
 
 {*
@@ -896,7 +896,7 @@ function IMG_isPNG(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isPNM(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isPNM(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isPNM' {$ENDIF} {$ENDIF};
 
 {*
@@ -940,7 +940,7 @@ function IMG_isPNM(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isSVG(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isSVG(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isSVG' {$ENDIF} {$ENDIF};
 
 {*
@@ -984,7 +984,7 @@ function IMG_isSVG(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isQOI(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isQOI(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isQOI' {$ENDIF} {$ENDIF};
 
 {*
@@ -1028,7 +1028,7 @@ function IMG_isQOI(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isTIF(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isTIF(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isTIF' {$ENDIF} {$ENDIF};
 
 {*
@@ -1072,7 +1072,7 @@ function IMG_isTIF(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isXCF(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isXCF(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isXCF' {$ENDIF} {$ENDIF};
 
 {*
@@ -1116,7 +1116,7 @@ function IMG_isXCF(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXV
  * \sa IMG_isWEBP
   }
-function IMG_isXPM(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isXPM(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isXPM' {$ENDIF} {$ENDIF};
 
 {*
@@ -1160,7 +1160,7 @@ function IMG_isXPM(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXPM
  * \sa IMG_isWEBP
   }
-function IMG_isXV(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isXV(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isXV' {$ENDIF} {$ENDIF};
 
 {*
@@ -1204,7 +1204,7 @@ function IMG_isXV(src: PSDL_IOStream): cbool; cdecl;
  * \sa IMG_isXPM
  * \sa IMG_isXV
   }
-function IMG_isWEBP(src: PSDL_IOStream): cbool; cdecl;
+function IMG_isWEBP(src: PSDL_IOStream): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_isWEBP' {$ENDIF} {$ENDIF};
 
 {*
@@ -1950,7 +1950,7 @@ function IMG_ReadXPMFromArrayToRGB888(xpm: PPAnsiChar): PSDL_Surface; cdecl;
  *
  * \sa IMG_SaveAVIF_IO
   }
-function IMG_SaveAVIF(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): cbool; cdecl;
+function IMG_SaveAVIF(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SaveAVIF' {$ENDIF} {$ENDIF};
 
 {*
@@ -1974,7 +1974,7 @@ function IMG_SaveAVIF(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): c
  *
  * \sa IMG_SaveAVIF
   }
-function IMG_SaveAVIF_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cbool; quality: cint): cbool; cdecl;
+function IMG_SaveAVIF_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: Boolean; quality: cint): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SaveAVIF_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -1991,7 +1991,7 @@ function IMG_SaveAVIF_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cbo
  *
  * \sa IMG_SavePNG_IO
   }
-function IMG_SavePNG(surface: PSDL_Surface; file_: PAnsiChar): cbool; cdecl;
+function IMG_SavePNG(surface: PSDL_Surface; file_: PAnsiChar): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SavePNG' {$ENDIF} {$ENDIF};
 
 {*
@@ -2013,7 +2013,7 @@ function IMG_SavePNG(surface: PSDL_Surface; file_: PAnsiChar): cbool; cdecl;
  *
  * \sa IMG_SavePNG
   }
-function IMG_SavePNG_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cbool): cbool; cdecl;
+function IMG_SavePNG_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: Boolean): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SavePNG_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -2032,7 +2032,7 @@ function IMG_SavePNG_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cboo
  *
  * \sa IMG_SaveJPG_IO
   }
-function IMG_SaveJPG(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): cbool; cdecl;
+function IMG_SaveJPG(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SaveJPG' {$ENDIF} {$ENDIF};
 
 {*
@@ -2056,7 +2056,7 @@ function IMG_SaveJPG(surface: PSDL_Surface; file_: PAnsiChar; quality: cint): cb
  *
  * \sa IMG_SaveJPG
   }
-function IMG_SaveJPG_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cbool; quality: cint): cbool; cdecl;
+function IMG_SaveJPG_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: Boolean; quality: cint): Boolean; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SaveJPG_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -2110,7 +2110,7 @@ function IMG_LoadAnimation(file_: PAnsiChar): PIMG_Animation; cdecl;
  *
  * \sa IMG_FreeAnimation
   }
-function IMG_LoadAnimation_IO(src: PSDL_IOStream; closeio: cbool): PIMG_Animation; cdecl;
+function IMG_LoadAnimation_IO(src: PSDL_IOStream; closeio: Boolean): PIMG_Animation; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_LoadAnimation_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -2141,7 +2141,7 @@ function IMG_LoadAnimation_IO(src: PSDL_IOStream; closeio: cbool): PIMG_Animatio
  * \sa IMG_LoadAnimation_IO
  * \sa IMG_FreeAnimation
   }
-function IMG_LoadAnimationTyped_IO(src: PSDL_IOStream; closeio: cbool; type_: PAnsiChar): PIMG_Animation; cdecl;
+function IMG_LoadAnimationTyped_IO(src: PSDL_IOStream; closeio: Boolean; type_: PAnsiChar): PIMG_Animation; cdecl;
   external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_LoadAnimationTyped_IO' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL3_textengine.pas
+++ b/units/SDL3_textengine.pas
@@ -138,7 +138,7 @@ type
       font: PTTF_Font;             {*< The font used by this text, read-only.  }
       color: TSDL_FColor;          {*< The color of the text, read-only.  }
 
-      needs_layout_update: cbool;  {*< True if the layout needs to be updated  }
+      needs_layout_update: Boolean;{*< True if the layout needs to be updated  }
       layout: PTTF_TextLayout;     {*< Cached layout information, read-only.  }
       x: cint;                     {*< The x offset of the upper left corner of this text, in pixels, read-only.  }
       y: cint;                     {*< The y offset of the upper left corner of this text, in pixels, read-only.  }
@@ -151,7 +151,7 @@ type
 
       props: TSDL_PropertiesID;    {*< Custom properties associated with this text, read-only. This field is created as-needed using TTF_GetTextProperties() and the properties may be then set and read normally  }
 
-      needs_engine_update: cbool;  {*< True if the engine text needs to be updated  }
+      needs_engine_update: Boolean;{*< True if the engine text needs to be updated  }
       engine: PTTF_TextEngine;     {*< The engine used to render this text, read-only.  }
       engine_text: Pointer;        {*< The implementation-specific representation of this text  }
     end;
@@ -181,7 +181,7 @@ type
        * \param userdata the userdata Pointer in this interface.
        * \param text the text object being created.
       }
-      CreateText: function(userdata: Pointer; text: PTTF_Text): cbool; cdecl;
+      CreateText: function(userdata: Pointer; text: PTTF_Text): Boolean; cdecl;
 
       {*
        * Destroy a text representation.

--- a/units/SDL3_ttf.pas
+++ b/units/SDL3_ttf.pas
@@ -174,7 +174,7 @@ type
  *
  * \sa TTF_Quit
   }
-function TTF_Init: cbool; cdecl;
+function TTF_Init: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_Init' {$ENDIF} {$ENDIF};
 
 {*
@@ -225,7 +225,7 @@ function TTF_OpenFont(file_: PAnsiChar; ptsize: cfloat): PTTF_Font; cdecl;
  *
  * \sa TTF_CloseFont
   }
-function TTF_OpenFontIO(src: PSDL_IOStream; closeio: cbool; ptsize: cfloat): PTTF_Font; cdecl;
+function TTF_OpenFontIO(src: PSDL_IOStream; closeio: Boolean; ptsize: cfloat): PTTF_Font; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_OpenFontIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -378,7 +378,7 @@ function TTF_GetFontGeneration(font: PTTF_Font): cuint32; cdecl;
  * \sa TTF_ClearFallbackFonts
  * \sa TTF_RemoveFallbackFont
   }
-function TTF_AddFallbackFont(font: PTTF_Font; fallback: PTTF_Font): cbool; cdecl;
+function TTF_AddFallbackFont(font: PTTF_Font; fallback: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_AddFallbackFont' {$ENDIF} {$ENDIF};
 
 {*
@@ -436,7 +436,7 @@ procedure TTF_ClearFallbackFonts(font: PTTF_Font); cdecl;
  *
  * \sa TTF_GetFontSize
   }
-function TTF_SetFontSize(font: PTTF_Font; ptsize: cfloat): cbool; cdecl;
+function TTF_SetFontSize(font: PTTF_Font; ptsize: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -460,7 +460,7 @@ function TTF_SetFontSize(font: PTTF_Font; ptsize: cfloat): cbool; cdecl;
  * \sa TTF_GetFontSize
  * \sa TTF_GetFontSizeDPI
   }
-function TTF_SetFontSizeDPI(font: PTTF_Font; ptsize: cfloat; hdpi: cint; vdpi: cint): cbool; cdecl;
+function TTF_SetFontSizeDPI(font: PTTF_Font; ptsize: cfloat; hdpi: cint; vdpi: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSizeDPI' {$ENDIF} {$ENDIF};
 
 {*
@@ -497,7 +497,7 @@ function TTF_GetFontSize(font: PTTF_Font): cfloat; cdecl;
  *
  * \sa TTF_SetFontSizeDPI
   }
-function TTF_GetFontDPI(font: PTTF_Font; hdpi: pcint; vdpi: pcint): cbool; cdecl;
+function TTF_GetFontDPI(font: PTTF_Font; hdpi: pcint; vdpi: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontDPI' {$ENDIF} {$ENDIF};
 
 {*
@@ -596,7 +596,7 @@ function TTF_GetFontStyle(font: PTTF_Font): TTTF_FontStyleFlags; cdecl;
  *
  * \sa TTF_GetFontOutline
   }
-function TTF_SetFontOutline(font: PTTF_Font; outline: cint): cbool; cdecl;
+function TTF_SetFontOutline(font: PTTF_Font; outline: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontOutline' {$ENDIF} {$ENDIF};
 
 {*
@@ -720,7 +720,7 @@ function TTF_GetFontHinting(font: PTTF_Font): TTTF_HintingFlags; cdecl;
  *
  * \sa TTF_GetFontSDF
   }
-function TTF_SetFontSDF(font: PTTF_Font; enabled: cbool): cbool; cdecl;
+function TTF_SetFontSDF(font: PTTF_Font; enabled: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontSDF' {$ENDIF} {$ENDIF};
 
 {*
@@ -736,7 +736,7 @@ function TTF_SetFontSDF(font: PTTF_Font; enabled: cbool): cbool; cdecl;
  *
  * \sa TTF_SetFontSDF
   }
-function TTF_GetFontSDF(font: PTTF_Font): cbool; cdecl;
+function TTF_GetFontSDF(font: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontSDF' {$ENDIF} {$ENDIF};
 
 {*
@@ -885,7 +885,7 @@ function TTF_GetFontLineSkip(font: PTTF_Font): cint; cdecl;
  *
  * \sa TTF_GetFontKerning
   }
-procedure TTF_SetFontKerning(font: PTTF_Font; enabled: cbool); cdecl;
+procedure TTF_SetFontKerning(font: PTTF_Font; enabled: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontKerning' {$ENDIF} {$ENDIF};
 
 {*
@@ -900,7 +900,7 @@ procedure TTF_SetFontKerning(font: PTTF_Font; enabled: cbool); cdecl;
  *
  * \sa TTF_SetFontKerning
   }
-function TTF_GetFontKerning(font: PTTF_Font): cbool; cdecl;
+function TTF_GetFontKerning(font: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerning' {$ENDIF} {$ENDIF};
 
 {*
@@ -919,7 +919,7 @@ function TTF_GetFontKerning(font: PTTF_Font): cbool; cdecl;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_FontIsFixedWidth(font: PTTF_Font): cbool; cdecl;
+function TTF_FontIsFixedWidth(font: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_FontIsFixedWidth' {$ENDIF} {$ENDIF};
 
 {*
@@ -937,7 +937,7 @@ function TTF_FontIsFixedWidth(font: PTTF_Font): cbool; cdecl;
  *
  * \sa TTF_SetFontSDF
   }
-function TTF_FontIsScalable(font: PTTF_Font): cbool; cdecl;
+function TTF_FontIsScalable(font: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_FontIsScalable' {$ENDIF} {$ENDIF};
 
 {*
@@ -1018,7 +1018,7 @@ const
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_SetFontDirection(font: PTTF_Font; direction: TTTF_Direction): cbool; cdecl;
+function TTF_SetFontDirection(font: PTTF_Font; direction: TTTF_Direction): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontDirection' {$ENDIF} {$ENDIF};
 
 {*
@@ -1054,7 +1054,7 @@ function TTF_GetFontDirection(font: PTTF_Font): TTTF_Direction; cdecl;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_SetFontScript(font: PTTF_Font; script: cuint32): cbool; cdecl;
+function TTF_SetFontScript(font: PTTF_Font; script: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontScript' {$ENDIF} {$ENDIF};
 
 {*
@@ -1101,7 +1101,7 @@ function TTF_GetGlyphScript(ch: cuint32): cuint32; cdecl;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_SetFontLanguage(font: PTTF_Font; language_bcp47: PAnsiChar): cbool; cdecl;
+function TTF_SetFontLanguage(font: PTTF_Font; language_bcp47: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetFontLanguage' {$ENDIF} {$ENDIF};
 
 {*
@@ -1116,7 +1116,7 @@ function TTF_SetFontLanguage(font: PTTF_Font; language_bcp47: PAnsiChar): cbool;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_FontHasGlyph(font: PTTF_Font; ch: cuint32): cbool; cdecl;
+function TTF_FontHasGlyph(font: PTTF_Font; ch: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_FontHasGlyph' {$ENDIF} {$ENDIF};
 
 {*
@@ -1202,7 +1202,7 @@ function TTF_GetGlyphImageForIndex(font: PTTF_Font; glyph_index: cuint32; image_
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetGlyphMetrics(font: PTTF_Font; ch: cuint32; minx: pcint; maxx: pcint; miny: pcint; maxy: pcint; advance: pcint): cbool; cdecl;
+function TTF_GetGlyphMetrics(font: PTTF_Font; ch: cuint32; minx: pcint; maxx: pcint; miny: pcint; maxy: pcint; advance: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetGlyphMetrics' {$ENDIF} {$ENDIF};
 
 {*
@@ -1219,7 +1219,7 @@ function TTF_GetGlyphMetrics(font: PTTF_Font; ch: cuint32; minx: pcint; maxx: pc
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetGlyphKerning(font: PTTF_Font; previous_ch: cuint32; ch: cuint32; kerning: pcint): cbool; cdecl;
+function TTF_GetGlyphKerning(font: PTTF_Font; previous_ch: cuint32; ch: cuint32; kerning: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetGlyphKerning' {$ENDIF} {$ENDIF};
 
 {*
@@ -1242,7 +1242,7 @@ function TTF_GetGlyphKerning(font: PTTF_Font; previous_ch: cuint32; ch: cuint32;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetStringSize(font: PTTF_Font; text: PAnsiChar; length: csize_t; w: pcint; h: pcint): cbool; cdecl;
+function TTF_GetStringSize(font: PTTF_Font; text: PAnsiChar; length: csize_t; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetStringSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1271,7 +1271,7 @@ function TTF_GetStringSize(font: PTTF_Font; text: PAnsiChar; length: csize_t; w:
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetStringSizeWrapped(font: PTTF_Font; text: PAnsiChar; length: csize_t; wrap_width: cint; w: pcint; h: pcint): cbool; cdecl;
+function TTF_GetStringSizeWrapped(font: PTTF_Font; text: PAnsiChar; length: csize_t; wrap_width: cint; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetStringSizeWrapped' {$ENDIF} {$ENDIF};
 
 {*
@@ -1300,7 +1300,7 @@ function TTF_GetStringSizeWrapped(font: PTTF_Font; text: PAnsiChar; length: csiz
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_MeasureString(font: PTTF_Font; text: PAnsiChar; length: csize_t; max_width: cint; measured_width: pcint; measured_length: pcsize_t): cbool; cdecl;
+function TTF_MeasureString(font: PTTF_Font; text: PAnsiChar; length: csize_t; max_width: cint; measured_width: pcint; measured_length: pcsize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_MeasureString' {$ENDIF} {$ENDIF};
 
 {*
@@ -1818,7 +1818,7 @@ function TTF_CreateSurfaceTextEngine: PTTF_TextEngine; cdecl;
  * \sa TTF_CreateSurfaceTextEngine
  * \sa TTF_CreateText
  }
-function TTF_DrawSurfaceText(text: PTTF_Text; x: cint; y: cint; surface: PSDL_Surface): cbool; cdecl;
+function TTF_DrawSurfaceText(text: PTTF_Text; x: cint; y: cint; surface: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_DrawSurfaceText' {$ENDIF} {$ENDIF};
 
 {*
@@ -1909,7 +1909,7 @@ const
  * \sa TTF_CreateRendererTextEngine
  * \sa TTF_CreateText
   }
-function TTF_DrawRendererText(text: PTTF_Text; x: cfloat; y: cfloat): cbool; cdecl;
+function TTF_DrawRendererText(text: PTTF_Text; x: cfloat; y: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_DrawRendererText' {$ENDIF} {$ENDIF};
 
 {*
@@ -2154,7 +2154,7 @@ function TTF_GetTextProperties(text: PTTF_Text): TSDL_PropertiesID; cdecl;
  *
  * \sa TTF_GetTextEngine
   }
-function TTF_SetTextEngine(text: PTTF_Text; engine: PTTF_TextEngine): cbool; cdecl;
+function TTF_SetTextEngine(text: PTTF_Text; engine: PTTF_TextEngine): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextEngine' {$ENDIF} {$ENDIF};
 
 {*
@@ -2195,7 +2195,7 @@ function TTF_GetTextEngine(text: PTTF_Text): PTTF_TextEngine; cdecl;
  *
  * \sa TTF_GetTextFont
   }
-function TTF_SetTextFont(text: PTTF_Text; font: PTTF_Font): cbool; cdecl;
+function TTF_SetTextFont(text: PTTF_Text; font: PTTF_Font): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextFont' {$ENDIF} {$ENDIF};
 
 {*
@@ -2231,7 +2231,7 @@ function TTF_GetTextFont(text: PTTF_Text): PTTF_Font; cdecl;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_SetTextDirection(text: PTTF_Text; direction: TTTF_Direction): cbool; cdecl;
+function TTF_SetTextDirection(text: PTTF_Text; direction: TTTF_Direction): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextDirection' {$ENDIF} {$ENDIF};
 
 {*
@@ -2265,7 +2265,7 @@ function TTF_GetTextDirection(text: PTTF_Text): TTTF_Direction; cdecl;
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_SetTextScript(text: PTTF_Text; script: cuint32): cbool; cdecl;
+function TTF_SetTextScript(text: PTTF_Text; script: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextScript' {$ENDIF} {$ENDIF};
 
 {*
@@ -2305,7 +2305,7 @@ function TTF_GetTextScript(text: PTTF_Text): cuint32; cdecl;
  * \sa TTF_GetTextColor
  * \sa TTF_SetTextColorFloat
   }
-function TTF_SetTextColor(text: PTTF_Text; r: cuint8; g: cuint8; b: cuint8; a: cuint8): cbool; cdecl;
+function TTF_SetTextColor(text: PTTF_Text; r: cuint8; g: cuint8; b: cuint8; a: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextColor' {$ENDIF} {$ENDIF};
 
 {*
@@ -2329,7 +2329,7 @@ function TTF_SetTextColor(text: PTTF_Text; r: cuint8; g: cuint8; b: cuint8; a: c
  * \sa TTF_GetTextColorFloat
  * \sa TTF_SetTextColor
   }
-function TTF_SetTextColorFloat(text: PTTF_Text; r: cfloat; g: cfloat; b: cfloat; a: cfloat): cbool; cdecl;
+function TTF_SetTextColorFloat(text: PTTF_Text; r: cfloat; g: cfloat; b: cfloat; a: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextColorFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -2355,7 +2355,7 @@ function TTF_SetTextColorFloat(text: PTTF_Text; r: cfloat; g: cfloat; b: cfloat;
  * \sa TTF_GetTextColorFloat
  * \sa TTF_SetTextColor
   }
-function TTF_GetTextColor(text: PTTF_Text; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): cbool; cdecl;
+function TTF_GetTextColor(text: PTTF_Text; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextColor' {$ENDIF} {$ENDIF};
 
 {*
@@ -2381,7 +2381,7 @@ function TTF_GetTextColor(text: PTTF_Text; r: pcuint8; g: pcuint8; b: pcuint8; a
  * \sa TTF_GetTextColor
  * \sa TTF_SetTextColorFloat
   }
-function TTF_GetTextColorFloat(text: PTTF_Text; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): cbool; cdecl;
+function TTF_GetTextColorFloat(text: PTTF_Text; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextColorFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -2403,7 +2403,7 @@ function TTF_GetTextColorFloat(text: PTTF_Text; r: pcfloat; g: pcfloat; b: pcflo
  *
  * \sa TTF_GetTextPosition
   }
-function TTF_SetTextPosition(text: PTTF_Text; x: cint; y: cint): cbool; cdecl;
+function TTF_SetTextPosition(text: PTTF_Text; x: cint; y: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextPosition' {$ENDIF} {$ENDIF};
 
 {*
@@ -2422,7 +2422,7 @@ function TTF_SetTextPosition(text: PTTF_Text; x: cint; y: cint): cbool; cdecl;
  *
  * \sa TTF_SetTextPosition
   }
-function TTF_GetTextPosition(text: PTTF_Text; x: pcint; y: pcint): cbool; cdecl;
+function TTF_GetTextPosition(text: PTTF_Text; x: pcint; y: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextPosition' {$ENDIF} {$ENDIF};
 
 {*
@@ -2443,7 +2443,7 @@ function TTF_GetTextPosition(text: PTTF_Text; x: pcint; y: pcint): cbool; cdecl;
  *
  * \sa TTF_GetTextWrapWidth
   }
-function TTF_SetTextWrapWidth(text: PTTF_Text; wrap_width: cint): cbool; cdecl;
+function TTF_SetTextWrapWidth(text: PTTF_Text; wrap_width: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextWrapWidth' {$ENDIF} {$ENDIF};
 
 {*
@@ -2462,7 +2462,7 @@ function TTF_SetTextWrapWidth(text: PTTF_Text; wrap_width: cint): cbool; cdecl;
  *
  * \sa TTF_SetTextWrapWidth
   }
-function TTF_GetTextWrapWidth(text: PTTF_Text; wrap_width: pcint): cbool; cdecl;
+function TTF_GetTextWrapWidth(text: PTTF_Text; wrap_width: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextWrapWidth' {$ENDIF} {$ENDIF};
 
 {*
@@ -2488,7 +2488,7 @@ function TTF_GetTextWrapWidth(text: PTTF_Text; wrap_width: pcint): cbool; cdecl;
  *
  * \sa TTF_TextWrapWhitespaceVisible
   }
-function TTF_SetTextWrapWhitespaceVisible(text: PTTF_Text; visible: cbool): cbool; cdecl;
+function TTF_SetTextWrapWhitespaceVisible(text: PTTF_Text; visible: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextWrapWhitespaceVisible' {$ENDIF} {$ENDIF};
 
 {*
@@ -2505,7 +2505,7 @@ function TTF_SetTextWrapWhitespaceVisible(text: PTTF_Text; visible: cbool): cboo
  *
  * \sa TTF_SetTextWrapWhitespaceVisible
   }
-function TTF_TextWrapWhitespaceVisible(text: PTTF_Text): cbool; cdecl;
+function TTF_TextWrapWhitespaceVisible(text: PTTF_Text): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_TextWrapWhitespaceVisible' {$ENDIF} {$ENDIF};
 
 {*
@@ -2529,7 +2529,7 @@ function TTF_TextWrapWhitespaceVisible(text: PTTF_Text): cbool; cdecl;
  * \sa TTF_DeleteTextString
  * \sa TTF_InsertTextString
   }
-function TTF_SetTextString(text: PTTF_Text; _string: PAnsiChar; length: csize_t): cbool; cdecl;
+function TTF_SetTextString(text: PTTF_Text; _string: PAnsiChar; length: csize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_SetTextString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2557,7 +2557,7 @@ function TTF_SetTextString(text: PTTF_Text; _string: PAnsiChar; length: csize_t)
  * \sa TTF_DeleteTextString
  * \sa TTF_SetTextString
   }
-function TTF_InsertTextString(text: PTTF_Text; offset: cint; _string: PAnsiChar; length: csize_t): cbool; cdecl;
+function TTF_InsertTextString(text: PTTF_Text; offset: cint; _string: PAnsiChar; length: csize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_InsertTextString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2581,7 +2581,7 @@ function TTF_InsertTextString(text: PTTF_Text; offset: cint; _string: PAnsiChar;
  * \sa TTF_InsertTextString
  * \sa TTF_SetTextString
   }
-function TTF_AppendTextString(text: PTTF_Text; _string: PAnsiChar; length: csize_t): cbool; cdecl;
+function TTF_AppendTextString(text: PTTF_Text; _string: PAnsiChar; length: csize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_AppendTextString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2608,7 +2608,7 @@ function TTF_AppendTextString(text: PTTF_Text; _string: PAnsiChar; length: csize
  * \sa TTF_InsertTextString
  * \sa TTF_SetTextString
   }
-function TTF_DeleteTextString(text: PTTF_Text; offset: cint; length: cint): cbool; cdecl;
+function TTF_DeleteTextString(text: PTTF_Text; offset: cint; length: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_DeleteTextString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2630,7 +2630,7 @@ function TTF_DeleteTextString(text: PTTF_Text; offset: cint; length: cint): cboo
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetTextSize(text: PTTF_Text; w: pcint; h: pcint): cbool; cdecl;
+function TTF_GetTextSize(text: PTTF_Text; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -2696,7 +2696,7 @@ type
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetTextSubString(text: PTTF_Text; offset: cint; substring: PTTF_SubString): cbool; cdecl;
+function TTF_GetTextSubString(text: PTTF_Text; offset: cint; substring: PTTF_SubString): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextSubString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2720,7 +2720,7 @@ function TTF_GetTextSubString(text: PTTF_Text; offset: cint; substring: PTTF_Sub
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetTextSubStringForLine(text: PTTF_Text; line: cint; substring: PTTF_SubString): cbool; cdecl;
+function TTF_GetTextSubStringForLine(text: PTTF_Text; line: cint; substring: PTTF_SubString): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextSubStringForLine' {$ENDIF} {$ENDIF};
 
 {*
@@ -2765,7 +2765,7 @@ function TTF_GetTextSubStringsForRange(text: PTTF_Text; offset: cint; length: ci
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetTextSubStringForPoint(text: PTTF_Text; x: cint; y: cint; substring: PTTF_SubString): cbool; cdecl;
+function TTF_GetTextSubStringForPoint(text: PTTF_Text; x: cint; y: cint; substring: PTTF_SubString): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetTextSubStringForPoint' {$ENDIF} {$ENDIF};
 
 {*
@@ -2784,7 +2784,7 @@ function TTF_GetTextSubStringForPoint(text: PTTF_Text; x: cint; y: cint; substri
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetPreviousTextSubString(text: PTTF_Text; substring: PTTF_SubString; previous: PTTF_SubString): cbool; cdecl;
+function TTF_GetPreviousTextSubString(text: PTTF_Text; substring: PTTF_SubString; previous: PTTF_SubString): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetPreviousTextSubString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2804,7 +2804,7 @@ function TTF_GetPreviousTextSubString(text: PTTF_Text; substring: PTTF_SubString
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_GetNextTextSubString(text: PTTF_Text; substring: PTTF_SubString; next: PTTF_SubString): cbool; cdecl;
+function TTF_GetNextTextSubString(text: PTTF_Text; substring: PTTF_SubString; next: PTTF_SubString): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetNextTextSubString' {$ENDIF} {$ENDIF};
 
 {*
@@ -2823,7 +2823,7 @@ function TTF_GetNextTextSubString(text: PTTF_Text; substring: PTTF_SubString; ne
  *
  * \since This function is available since SDL_ttf 3.0.0.
   }
-function TTF_UpdateText(text: PTTF_Text): cbool; cdecl;
+function TTF_UpdateText(text: PTTF_Text): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_UpdateText' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_asyncio.inc
+++ b/units/SDL_asyncio.inc
@@ -260,7 +260,7 @@ function SDL_GetAsyncIOSize(asyncio: PSDL_AsyncIO): cint64; cdecl;
  * \sa SDL_WriteAsyncIO
  * \sa SDL_CreateAsyncIOQueue
   }
-function SDL_ReadAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; size: cuint64; queue: PSDL_AsyncIOQueue; userdata: Pointer): cbool; cdecl;
+function SDL_ReadAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; size: cuint64; queue: PSDL_AsyncIOQueue; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadAsyncIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -298,7 +298,7 @@ function SDL_ReadAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; s
  * \sa SDL_ReadAsyncIO
  * \sa SDL_CreateAsyncIOQueue
   }
-function SDL_WriteAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; size: cuint64; queue: PSDL_AsyncIOQueue; userdata: Pointer): cbool; cdecl;
+function SDL_WriteAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; size: cuint64; queue: PSDL_AsyncIOQueue; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteAsyncIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -348,7 +348,7 @@ function SDL_WriteAsyncIO(asyncio: PSDL_AsyncIO; ptr: Pointer; offset: cuint64; 
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_CloseAsyncIO(asyncio: PSDL_AsyncIO; flush: cbool; queue: PSDL_AsyncIOQueue; userdata: Pointer): cbool; cdecl;
+function SDL_CloseAsyncIO(asyncio: PSDL_AsyncIO; flush: Boolean; queue: PSDL_AsyncIOQueue; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CloseAsyncIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -426,7 +426,7 @@ procedure SDL_DestroyAsyncIOQueue(queue: PSDL_AsyncIOQueue); cdecl;
  *
  * \sa SDL_WaitAsyncIOResult
   }
-function SDL_GetAsyncIOResult(queue: PSDL_AsyncIOQueue; outcome: PSDL_AsyncIOOutcome): cbool; cdecl;
+function SDL_GetAsyncIOResult(queue: PSDL_AsyncIOQueue; outcome: PSDL_AsyncIOOutcome): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetAsyncIOResult' {$ENDIF} {$ENDIF};
 
 {*
@@ -471,7 +471,7 @@ function SDL_GetAsyncIOResult(queue: PSDL_AsyncIOQueue; outcome: PSDL_AsyncIOOut
  *
  * \sa SDL_SignalAsyncIOQueue
   }
-function SDL_WaitAsyncIOResult(queue: PSDL_AsyncIOQueue; outcome: PSDL_AsyncIOOutcome; timeoutMS: cint32): cbool; cdecl;
+function SDL_WaitAsyncIOResult(queue: PSDL_AsyncIOQueue; outcome: PSDL_AsyncIOOutcome; timeoutMS: cint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitAsyncIOResult' {$ENDIF} {$ENDIF};
 
 {*
@@ -529,6 +529,6 @@ procedure SDL_SignalAsyncIOQueue(queue: PSDL_AsyncIOQueue); cdecl;
  *
  * \sa SDL_LoadFile_IO
   }
-function SDL_LoadFileAsync(file_: PAnsiChar; queue: PSDL_AsyncIOQueue; userdata: Pointer): cbool; cdecl;
+function SDL_LoadFileAsync(file_: PAnsiChar; queue: PSDL_AsyncIOQueue; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LoadFileAsync' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_atomic.inc
+++ b/units/SDL_atomic.inc
@@ -74,7 +74,7 @@ type
  * \sa SDL_LockSpinlock
  * \sa SDL_UnlockSpinlock
   }
-function SDL_TryLockSpinlock(lock: PSDL_SpinLock): cbool; cdecl;
+function SDL_TryLockSpinlock(lock: PSDL_SpinLock): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_TryLockSpinlock' {$ENDIF} {$ENDIF};
 
 {*
@@ -314,7 +314,7 @@ type
  * \sa SDL_GetAtomicInt
  * \sa SDL_SetAtomicInt
   }
-function SDL_CompareAndSwapAtomicInt(a: PSDL_AtomicInt; oldval: cint; newval: cint): cbool; cdecl;
+function SDL_CompareAndSwapAtomicInt(a: PSDL_AtomicInt; oldval: cint; newval: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CompareAndSwapAtomicInt' {$ENDIF} {$ENDIF};
 
 {*
@@ -409,7 +409,7 @@ function SDL_AtomicIncRef(a: PSDL_AtomicInt): cint;
  *
  * \sa SDL_AtomicIncRef
   }
-function SDL_AtomicDecRef(a: PSDL_AtomicInt): cbool;
+function SDL_AtomicDecRef(a: PSDL_AtomicInt): Boolean;
 
 {*
  * A type representing an atomic unsigned 32-bit value.
@@ -462,7 +462,7 @@ type
  * \sa SDL_GetAtomicU32
  * \sa SDL_SetAtomicU32
   }
-function SDL_CompareAndSwapAtomicU32(a: PSDL_AtomicU32; oldval: cuint32; newval: cuint32): cbool; cdecl;
+function SDL_CompareAndSwapAtomicU32(a: PSDL_AtomicU32; oldval: cuint32; newval: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CompareAndSwapAtomicU32' {$ENDIF} {$ENDIF};
 
 {*
@@ -523,7 +523,7 @@ function SDL_GetAtomicU32(a: PSDL_AtomicU32): cuint32; cdecl;
  * \sa SDL_GetAtomicPointer
  * \sa SDL_SetAtomicPointer
   }
-function SDL_CompareAndSwapAtomicPointer(a: PPointer; oldval: Pointer; newval: Pointer): cbool; cdecl;
+function SDL_CompareAndSwapAtomicPointer(a: PPointer; oldval: Pointer; newval: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CompareAndSwapAtomicPointer' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_audio.inc
+++ b/units/SDL_audio.inc
@@ -547,7 +547,7 @@ function SDL_GetAudioDeviceName(devid: TSDL_AudioDeviceID): PAnsiChar; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetAudioDeviceFormat(devid: TSDL_AudioDeviceID; spec: PSDL_AudioSpec; sample_frames: pcint): cbool; cdecl;
+function SDL_GetAudioDeviceFormat(devid: TSDL_AudioDeviceID; spec: PSDL_AudioSpec; sample_frames: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetAudioDeviceFormat' {$ENDIF} {$ENDIF};
 
 {*
@@ -680,7 +680,7 @@ function SDL_OpenAudioDevice(devid: TSDL_AudioDeviceID; spec: PSDL_AudioSpec): T
  * \sa SDL_ResumeAudioDevice
  * \sa SDL_AudioDevicePaused
   }
-function SDL_PauseAudioDevice(dev: TSDL_AudioDeviceID): cbool; cdecl;
+function SDL_PauseAudioDevice(dev: TSDL_AudioDeviceID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PauseAudioDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -709,7 +709,7 @@ function SDL_PauseAudioDevice(dev: TSDL_AudioDeviceID): cbool; cdecl;
  * \sa SDL_AudioDevicePaused
  * \sa SDL_PauseAudioDevice
   }
-function SDL_ResumeAudioDevice(dev: TSDL_AudioDeviceID): cbool; cdecl;
+function SDL_ResumeAudioDevice(dev: TSDL_AudioDeviceID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ResumeAudioDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -732,7 +732,7 @@ function SDL_ResumeAudioDevice(dev: TSDL_AudioDeviceID): cbool; cdecl;
  * \sa SDL_PauseAudioDevice
  * \sa SDL_ResumeAudioDevice
   }
-function SDL_AudioDevicePaused(dev: TSDL_AudioDeviceID): cbool; cdecl;
+function SDL_AudioDevicePaused(dev: TSDL_AudioDeviceID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AudioDevicePaused' {$ENDIF} {$ENDIF};
 
 {*
@@ -792,7 +792,7 @@ function SDL_GetAudioDeviceGain(devid: TSDL_AudioDeviceID): cfloat; cdecl;
  *
  * \sa SDL_GetAudioDeviceGain
   }
-function SDL_SetAudioDeviceGain(devid: TSDL_AudioDeviceID; gain: cfloat): cbool; cdecl;
+function SDL_SetAudioDeviceGain(devid: TSDL_AudioDeviceID; gain: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioDeviceGain' {$ENDIF} {$ENDIF};
 
 {*
@@ -852,7 +852,7 @@ procedure SDL_CloseAudioDevice(devid: TSDL_AudioDeviceID); cdecl;
  * \sa SDL_UnbindAudioStream
  * \sa SDL_GetAudioStreamDevice
   }
-function SDL_BindAudioStreams(devid: TSDL_AudioDeviceID; streams: PPSDL_AudioStream; num_streams: cint): cbool; cdecl;
+function SDL_BindAudioStreams(devid: TSDL_AudioDeviceID; streams: PPSDL_AudioStream; num_streams: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BindAudioStreams' {$ENDIF} {$ENDIF};
 
 {*
@@ -874,7 +874,7 @@ function SDL_BindAudioStreams(devid: TSDL_AudioDeviceID; streams: PPSDL_AudioStr
  * \sa SDL_UnbindAudioStream
  * \sa SDL_GetAudioStreamDevice
   }
-function SDL_BindAudioStream(devid: TSDL_AudioDeviceID; stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_BindAudioStream(devid: TSDL_AudioDeviceID; stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BindAudioStream' {$ENDIF} {$ENDIF};
 
 {*
@@ -989,7 +989,7 @@ function SDL_GetAudioStreamProperties(stream: PSDL_AudioStream): TSDL_Properties
  *
  * \sa SDL_SetAudioStreamFormat
   }
-function SDL_GetAudioStreamFormat(stream: PSDL_AudioStream; src_spec: PSDL_AudioSpec; dst_spec: PSDL_AudioSpec): cbool; cdecl;
+function SDL_GetAudioStreamFormat(stream: PSDL_AudioStream; src_spec: PSDL_AudioSpec; dst_spec: PSDL_AudioSpec): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetAudioStreamFormat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1021,7 +1021,7 @@ function SDL_GetAudioStreamFormat(stream: PSDL_AudioStream; src_spec: PSDL_Audio
  * \sa SDL_GetAudioStreamFormat
  * \sa SDL_SetAudioStreamFrequencyRatio
   }
-function SDL_SetAudioStreamFormat(stream: PSDL_AudioStream; src_spec: PSDL_AudioSpec; dst_spec: PSDL_AudioSpec): cbool; cdecl;
+function SDL_SetAudioStreamFormat(stream: PSDL_AudioStream; src_spec: PSDL_AudioSpec; dst_spec: PSDL_AudioSpec): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamFormat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1067,7 +1067,7 @@ function SDL_GetAudioStreamFrequencyRatio(stream: PSDL_AudioStream): cfloat; cde
  * \sa SDL_GetAudioStreamFrequencyRatio
  * \sa SDL_SetAudioStreamFormat
   }
-function SDL_SetAudioStreamFrequencyRatio(stream: PSDL_AudioStream; ratio: cfloat): cbool; cdecl;
+function SDL_SetAudioStreamFrequencyRatio(stream: PSDL_AudioStream; ratio: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamFrequencyRatio' {$ENDIF} {$ENDIF};
 
 {*
@@ -1115,7 +1115,7 @@ function SDL_GetAudioStreamGain(stream: PSDL_AudioStream): cfloat; cdecl;
  *
  * \sa SDL_GetAudioStreamGain
   }
-function SDL_SetAudioStreamGain(stream: PSDL_AudioStream; gain: cfloat): cbool; cdecl;
+function SDL_SetAudioStreamGain(stream: PSDL_AudioStream; gain: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamGain' {$ENDIF} {$ENDIF};
 
 {*
@@ -1217,7 +1217,7 @@ function SDL_GetAudioStreamOutputChannelMap(stream: PSDL_AudioStream; count: pci
  *
  * \sa SDL_SetAudioStreamInputChannelMap
   }
-function SDL_SetAudioStreamInputChannelMap(stream: PSDL_AudioStream; chmap: pcint; count: cint): cbool; cdecl;
+function SDL_SetAudioStreamInputChannelMap(stream: PSDL_AudioStream; chmap: pcint; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamInputChannelMap' {$ENDIF} {$ENDIF};
 
 {*
@@ -1266,7 +1266,7 @@ function SDL_SetAudioStreamInputChannelMap(stream: PSDL_AudioStream; chmap: pcin
  * \sa SDL_SetAudioStreamInputChannelMap
   }
 
-function SDL_SetAudioStreamOutputChannelMap(stream: PSDL_AudioStream; chmap: pcint; count: cint): cbool; cdecl;
+function SDL_SetAudioStreamOutputChannelMap(stream: PSDL_AudioStream; chmap: pcint; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamOutputChannelMap' {$ENDIF} {$ENDIF};
 
 {*
@@ -1297,7 +1297,7 @@ function SDL_SetAudioStreamOutputChannelMap(stream: PSDL_AudioStream; chmap: pci
  * \sa SDL_GetAudioStreamData
  * \sa SDL_GetAudioStreamQueued
   }
-function SDL_PutAudioStreamData(stream: PSDL_AudioStream; buf: Pointer; len: cint): cbool; cdecl;
+function SDL_PutAudioStreamData(stream: PSDL_AudioStream; buf: Pointer; len: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PutAudioStreamData' {$ENDIF} {$ENDIF};
 
 {*
@@ -1415,7 +1415,7 @@ function SDL_GetAudioStreamQueued(stream: PSDL_AudioStream): cint; cdecl;
  *
  * \sa SDL_PutAudioStreamData
   }
-function SDL_FlushAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_FlushAudioStream(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FlushAudioStream' {$ENDIF} {$ENDIF};
 
 {*
@@ -1437,7 +1437,7 @@ function SDL_FlushAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
  * \sa SDL_GetAudioStreamQueued
  * \sa SDL_PutAudioStreamData
   }
-function SDL_ClearAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_ClearAudioStream(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearAudioStream' {$ENDIF} {$ENDIF};
 
 {*
@@ -1462,7 +1462,7 @@ function SDL_ClearAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
  *
  * \sa SDL_ResumeAudioStreamDevice
   }
-function SDL_PauseAudioStreamDevice(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_PauseAudioStreamDevice(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PauseAudioStreamDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -1483,7 +1483,7 @@ function SDL_PauseAudioStreamDevice(stream: PSDL_AudioStream): cbool; cdecl;
  *
  * \sa SDL_PauseAudioStreamDevice
   }
-function SDL_ResumeAudioStreamDevice(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_ResumeAudioStreamDevice(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ResumeAudioStreamDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -1512,7 +1512,7 @@ function SDL_ResumeAudioStreamDevice(stream: PSDL_AudioStream): cbool; cdecl;
  *
  * \sa SDL_UnlockAudioStream
   }
-function SDL_LockAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_LockAudioStream(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LockAudioStream' {$ENDIF} {$ENDIF};
 
 {*
@@ -1531,7 +1531,7 @@ function SDL_LockAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
  *
  * \sa SDL_LockAudioStream
   }
-function SDL_UnlockAudioStream(stream: PSDL_AudioStream): cbool; cdecl;
+function SDL_UnlockAudioStream(stream: PSDL_AudioStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UnlockAudioStream' {$ENDIF} {$ENDIF};
 
 {*
@@ -1621,7 +1621,7 @@ type
  *
  * \sa SDL_SetAudioStreamPutCallback
   }
-function SDL_SetAudioStreamGetCallback(stream: PSDL_AudioStream; callback: TSDL_AudioStreamCallback; userdata: Pointer): cbool; cdecl;
+function SDL_SetAudioStreamGetCallback(stream: PSDL_AudioStream; callback: TSDL_AudioStreamCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamGetCallback' {$ENDIF} {$ENDIF};
 
 {*
@@ -1671,7 +1671,7 @@ function SDL_SetAudioStreamGetCallback(stream: PSDL_AudioStream; callback: TSDL_
  *
  * \sa SDL_SetAudioStreamGetCallback
   }
-function SDL_SetAudioStreamPutCallback(stream: PSDL_AudioStream; callback: TSDL_AudioStreamCallback; userdata: Pointer): cbool; cdecl;
+function SDL_SetAudioStreamPutCallback(stream: PSDL_AudioStream; callback: TSDL_AudioStreamCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioStreamPutCallback' {$ENDIF} {$ENDIF};
 
 {*
@@ -1849,7 +1849,7 @@ type
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetAudioPostmixCallback(devid: TSDL_AudioDeviceID; callback: TSDL_AudioPostmixCallback; userdata: Pointer): cbool; cdecl;
+function SDL_SetAudioPostmixCallback(devid: TSDL_AudioDeviceID; callback: TSDL_AudioPostmixCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAudioPostmixCallback' {$ENDIF} {$ENDIF};
 
 {*
@@ -1930,7 +1930,7 @@ function SDL_SetAudioPostmixCallback(devid: TSDL_AudioDeviceID; callback: TSDL_A
  * \sa SDL_free
  * \sa SDL_LoadWAV
   }
-function SDL_LoadWAV_IO(src: PSDL_IOStream; closeio: cbool; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): cbool; cdecl;
+function SDL_LoadWAV_IO(src: PSDL_IOStream; closeio: Boolean; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LoadWAV_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -1967,7 +1967,7 @@ function SDL_LoadWAV_IO(src: PSDL_IOStream; closeio: cbool; spec: PSDL_AudioSpec
  * \sa SDL_free
  * \sa SDL_LoadWAV_IO
   }
-function SDL_LoadWAV(path: PAnsiChar; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): cbool; cdecl;
+function SDL_LoadWAV(path: PAnsiChar; spec: PSDL_AudioSpec; audio_buf: ppcuint8; audio_len: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LoadWAV' {$ENDIF} {$ENDIF};
 
 {*
@@ -2004,7 +2004,7 @@ function SDL_LoadWAV(path: PAnsiChar; spec: PSDL_AudioSpec; audio_buf: ppcuint8;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_MixAudio(dst: pcuint8; src: pcuint8; format: TSDL_AudioFormat; len: cuint32; volume: cfloat): cbool; cdecl;
+function SDL_MixAudio(dst: pcuint8; src: pcuint8; format: TSDL_AudioFormat; len: cuint32; volume: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_MixAudio' {$ENDIF} {$ENDIF};
 
 {*
@@ -2035,7 +2035,7 @@ function SDL_MixAudio(dst: pcuint8; src: pcuint8; format: TSDL_AudioFormat; len:
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ConvertAudioSamples(src_spec: PSDL_AudioSpec; src_data: pcuint8; src_len: cint; dst_spec: PSDL_AudioSpec; dst_data: ppcuint8; dst_len: pcint): cbool; cdecl;
+function SDL_ConvertAudioSamples(src_spec: PSDL_AudioSpec; src_data: pcuint8; src_len: cint; dst_spec: PSDL_AudioSpec; dst_data: ppcuint8; dst_len: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ConvertAudioSamples' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_camera.inc
+++ b/units/SDL_camera.inc
@@ -378,7 +378,7 @@ function SDL_GetCameraProperties(camera: PSDL_Camera): TSDL_PropertiesID; cdecl;
  *
  * \sa SDL_OpenCamera
   }
-function SDL_GetCameraFormat(camera: PSDL_Camera; spec: PSDL_CameraSpec): cbool; cdecl;
+function SDL_GetCameraFormat(camera: PSDL_Camera; spec: PSDL_CameraSpec): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetCameraFormat' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_clipboard.inc
+++ b/units/SDL_clipboard.inc
@@ -76,7 +76,7 @@
  * \sa SDL_GetClipboardText
  * \sa SDL_HasClipboardText
   }
-function SDL_SetClipboardText(text: PAnsiChar): cbool; cdecl;
+function SDL_SetClipboardText(text: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetClipboardText' {$ENDIF} {$ENDIF};
 
 {*
@@ -111,7 +111,7 @@ function SDL_GetClipboardText: PAnsiChar; cdecl;
  * \sa SDL_GetClipboardText
  * \sa SDL_SetClipboardText
   }
-function SDL_HasClipboardText: cbool; cdecl;
+function SDL_HasClipboardText: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasClipboardText' {$ENDIF} {$ENDIF};
 
 {*
@@ -128,7 +128,7 @@ function SDL_HasClipboardText: cbool; cdecl;
  * \sa SDL_GetPrimarySelectionText
  * \sa SDL_HasPrimarySelectionText
   }
-function SDL_SetPrimarySelectionText(text: PAnsiChar): cbool; cdecl;
+function SDL_SetPrimarySelectionText(text: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetPrimarySelectionText' {$ENDIF} {$ENDIF};
 
 {*
@@ -164,7 +164,7 @@ function SDL_GetPrimarySelectionText: PAnsiChar; cdecl;
  * \sa SDL_GetPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
   }
-function SDL_HasPrimarySelectionText: cbool; cdecl;
+function SDL_HasPrimarySelectionText: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasPrimarySelectionText' {$ENDIF} {$ENDIF};
 
 {*
@@ -235,7 +235,7 @@ type
  * \sa SDL_GetClipboardData
  * \sa SDL_HasClipboardData
   }
-function SDL_SetClipboardData(callback: TSDL_ClipboardDataCallback; cleanup: TSDL_ClipboardCleanupCallback; userdata: Pointer; mime_types: PPAnsiChar; num_mime_types: csize_t): cbool; cdecl;
+function SDL_SetClipboardData(callback: TSDL_ClipboardDataCallback; cleanup: TSDL_ClipboardCleanupCallback; userdata: Pointer; mime_types: PPAnsiChar; num_mime_types: csize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetClipboardData' {$ENDIF} {$ENDIF};
 
 {*
@@ -250,7 +250,7 @@ function SDL_SetClipboardData(callback: TSDL_ClipboardDataCallback; cleanup: TSD
  *
  * \sa SDL_SetClipboardData
   }
-function SDL_ClearClipboardData: cbool; cdecl;
+function SDL_ClearClipboardData: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearClipboardData' {$ENDIF} {$ENDIF};
 
 {*
@@ -289,7 +289,7 @@ function SDL_GetClipboardData(mime_type: PAnsiChar; size: pcsize_t): Pointer; cd
  * \sa SDL_SetClipboardData
  * \sa SDL_GetClipboardData
   }
-function SDL_HasClipboardData(mime_type: PAnsiChar): cbool; cdecl;
+function SDL_HasClipboardData(mime_type: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasClipboardData' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_cpuinfo.inc
+++ b/units/SDL_cpuinfo.inc
@@ -75,7 +75,7 @@ function SDL_GetCPUCacheLineSize: cint; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_HasAltiVec: cbool; cdecl;
+function SDL_HasAltiVec: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAltiVec' {$ENDIF} {$ENDIF};
 
 {*
@@ -89,7 +89,7 @@ function SDL_HasAltiVec: cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_HasMMX: cbool; cdecl;
+function SDL_HasMMX: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasMMX' {$ENDIF} {$ENDIF};
 
 {*
@@ -108,7 +108,7 @@ function SDL_HasMMX: cbool; cdecl;
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
   }
-function SDL_HasSSE: cbool; cdecl;
+function SDL_HasSSE: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasSSE' {$ENDIF} {$ENDIF};
 
 {*
@@ -127,7 +127,7 @@ function SDL_HasSSE: cbool; cdecl;
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
   }
-function SDL_HasSSE2: cbool; cdecl;
+function SDL_HasSSE2: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasSSE2' {$ENDIF} {$ENDIF};
 
 {*
@@ -146,7 +146,7 @@ function SDL_HasSSE2: cbool; cdecl;
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
   }
-function SDL_HasSSE3: cbool; cdecl;
+function SDL_HasSSE3: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasSSE3' {$ENDIF} {$ENDIF};
 
 {*
@@ -165,7 +165,7 @@ function SDL_HasSSE3: cbool; cdecl;
  * \sa SDL_HasSSE3
  * \sa SDL_HasSSE42
   }
-function SDL_HasSSE41: cbool; cdecl;
+function SDL_HasSSE41: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasSSE41' {$ENDIF} {$ENDIF};
 
 {*
@@ -184,7 +184,7 @@ function SDL_HasSSE41: cbool; cdecl;
  * \sa SDL_HasSSE3
  * \sa SDL_HasSSE41
   }
-function SDL_HasSSE42: cbool; cdecl;
+function SDL_HasSSE42: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasSSE42' {$ENDIF} {$ENDIF};
 
 {*
@@ -201,7 +201,7 @@ function SDL_HasSSE42: cbool; cdecl;
  * \sa SDL_HasAVX2
  * \sa SDL_HasAVX512F
   }
-function SDL_HasAVX: cbool; cdecl;
+function SDL_HasAVX: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAVX' {$ENDIF} {$ENDIF};
 
 {*
@@ -218,7 +218,7 @@ function SDL_HasAVX: cbool; cdecl;
  * \sa SDL_HasAVX
  * \sa SDL_HasAVX512F
   }
-function SDL_HasAVX2: cbool; cdecl;
+function SDL_HasAVX2: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAVX2' {$ENDIF} {$ENDIF};
 
 {*
@@ -235,7 +235,7 @@ function SDL_HasAVX2: cbool; cdecl;
  * \sa SDL_HasAVX
  * \sa SDL_HasAVX2
   }
-function SDL_HasAVX512F: cbool; cdecl;
+function SDL_HasAVX512F: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAVX512F' {$ENDIF} {$ENDIF};
 
 {*
@@ -253,7 +253,7 @@ function SDL_HasAVX512F: cbool; cdecl;
  *
  * \sa SDL_HasNEON
   }
-function SDL_HasARMSIMD: cbool; cdecl;
+function SDL_HasARMSIMD: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasARMSIMD' {$ENDIF} {$ENDIF};
 
 {*
@@ -267,7 +267,7 @@ function SDL_HasARMSIMD: cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_HasNEON: cbool; cdecl;
+function SDL_HasNEON: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasNEON' {$ENDIF} {$ENDIF};
 
 {*
@@ -282,7 +282,7 @@ function SDL_HasNEON: cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_HasLSX: cbool; cdecl;
+function SDL_HasLSX: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasLSX' {$ENDIF} {$ENDIF};
 
 {*
@@ -297,7 +297,7 @@ function SDL_HasLSX: cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_HasLASX: cbool; cdecl;
+function SDL_HasLASX: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasLASX' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_dialog.inc
+++ b/units/SDL_dialog.inc
@@ -137,7 +137,7 @@ type
  * \sa SDL_ShowSaveFileDialog
  * \sa SDL_ShowOpenFolderDialog
   }
-procedure SDL_ShowOpenFileDialog(callback: TSDL_DialogFileCallback; userdata: Pointer; window: PSDL_Window; filters: PSDL_DialogFileFilter; nfilters: cint; default_location: PAnsiChar; allow_many: cbool); cdecl;
+procedure SDL_ShowOpenFileDialog(callback: TSDL_DialogFileCallback; userdata: Pointer; window: PSDL_Window; filters: PSDL_DialogFileFilter; nfilters: cint; default_location: PAnsiChar; allow_many: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowOpenFileDialog' {$ENDIF} {$ENDIF};
 
 {*
@@ -233,7 +233,7 @@ procedure SDL_ShowSaveFileDialog(callback: TSDL_DialogFileCallback; userdata: Po
 * \sa SDL_ShowSaveFileDialog
 * \sa SDL_ShowFileDialogWithProperties
   }
-procedure SDL_ShowOpenFolderDialog(callback: TSDL_DialogFileCallback; userdata: Pointer; window: PSDL_Window; default_location: PAnsiChar; allow_many: cbool); cdecl;
+procedure SDL_ShowOpenFolderDialog(callback: TSDL_DialogFileCallback; userdata: Pointer; window: PSDL_Window; default_location: PAnsiChar; allow_many: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowOpenFolderDialog' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_error.inc
+++ b/units/SDL_error.inc
@@ -59,9 +59,9 @@
  * \sa SDL_GetError
  * \sa SDL_SetErrorV
   }
-function SDL_SetError(fmt: PAnsiChar; Args: array of const): cbool; cdecl; overload;
+function SDL_SetError(fmt: PAnsiChar; Args: array of const): Boolean; cdecl; overload;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetError' {$ENDIF} {$ENDIF};
-function SDL_SetError(fmt: PAnsiChar): cbool; cdecl; overload;
+function SDL_SetError(fmt: PAnsiChar): Boolean; cdecl; overload;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetError' {$ENDIF} {$ENDIF};
 
 {*
@@ -82,7 +82,7 @@ function SDL_SetError(fmt: PAnsiChar): cbool; cdecl; overload;
  * \sa SDL_SetError
   }
 { #todo : SDL3-for-Pascal: How to handle va_list? }
-//function SDL_SetErrorV(fmt: PAnsiChar; ap: va_list): cbool; cdecl;
+//function SDL_SetErrorV(fmt: PAnsiChar; ap: va_list): Boolean; cdecl;
 //  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetErrorV' {$ENDIF} {$ENDIF};
 
 {*
@@ -96,7 +96,7 @@ function SDL_SetError(fmt: PAnsiChar): cbool; cdecl; overload;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_OutOfMemory: cbool; cdecl;
+function SDL_OutOfMemory: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_OutOfMemory' {$ENDIF} {$ENDIF};
 
 {*
@@ -149,6 +149,6 @@ function SDL_GetError: PAnsiChar; cdecl;
  * \sa SDL_GetError
  * \sa SDL_SetError
   }
-function SDL_ClearError: cbool; cdecl;
+function SDL_ClearError: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearError' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_events.inc
+++ b/units/SDL_events.inc
@@ -303,8 +303,8 @@ type
       key: TSDL_Keycode;            {*< SDL virtual key code  }
       mod_: TSDL_Keymod;            {*< current key modifiers  }
       raw: cuint16;                 {*< The platform dependent scancode for this event  }
-      down: cbool;                  {*< true if the key is pressed  }
-      repeat_: cbool;               {*< true if this is a key repeat  }
+      down: Boolean;                {*< true if the key is pressed  }
+      repeat_: Boolean;             {*< true if this is a key repeat  }
     end;
 
 {*
@@ -343,7 +343,7 @@ type
       candidates: ^PAnsiChar;         {*< The list of candidates, or nil if there are no candidates available  }
       num_candidates: cint32;         {*< The number of strings in `candidates`  }
       selected_candidate: cint32;     {*< The index of the selected candidate, or -1 if no candidate is selected  }
-      horizontal: cbool;              {*< true if the list is horizontal, false if it's vertical  }
+      horizontal: Boolean;            {*< true if the list is horizontal, false if it's vertical  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -418,7 +418,7 @@ type
       windowID: TSDL_WindowID;       {*< The window with mouse focus, if any  }
       which: TSDL_MouseID;           {*< The mouse instance id, SDL_TOUCH_MOUSEID  }
       button: cuint8;                {*< The mouse button index  }
-      down: cbool;                   {*< true if the button is pressed  }
+      down: Boolean;                 {*< true if the button is pressed  }
       clicks: cuint8;                {*< 1 for single-click, 2 for double-click, etc.  }
       padding: cuint8;
       x: cfloat;                     {*< X coordinate, relative to window  }
@@ -521,7 +521,7 @@ type
       timestamp: cuint64;        {*< In nanoseconds, populated using SDL_GetTicksNS()  }
       which: TSDL_JoystickID;    {*< The joystick instance id  }
       button: cuint8;            {*< The joystick button index  }
-      down: cbool;               {*< true if the button is pressed  }
+      down: Boolean;             {*< true if the button is pressed  }
       padding1: cuint8;
       padding2: cuint8;
     end;
@@ -594,7 +594,7 @@ type
       timestamp: cuint64;       {*< In nanoseconds, populated using SDL_GetTicksNS()  }
       which: TSDL_JoystickID;   {*< The joystick instance id  }
       button: cuint8;           {*< The gamepad button (SDL_GamepadButton)  }
-      down: cbool;              {*< true if the button is pressed  }
+      down: Boolean;            {*< true if the button is pressed  }
       padding1: cuint8;
       padding2: cuint8;
     end;
@@ -670,7 +670,7 @@ type
       reserved: cuint32;
       timestamp: cuint64;          {*< In nanoseconds, populated using SDL_GetTicksNS()  }
       which: TSDL_AudioDeviceID;   {*< SDL_AudioDeviceID for the device being added or removed or changing  }
-      recording: cbool;            {*< false if a playback device, true if a recording device.  }
+      recording: Boolean;          {*< false if a playback device, true if a recording device.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -793,8 +793,8 @@ type
       pen_state: TSDL_PenInputFlags;  {*< Complete pen input state at time of event  }
       x: cfloat;                      {*< X coordinate, relative to window  }
       y: cfloat;                      {*< Y coordinate, relative to window  }
-      eraser: cbool;                  {*< true if eraser end is used (not all pens support this).  }
-      down: cbool;                    {*< true if the pen is touching or false if the pen is lifted off  }
+      eraser: Boolean;                {*< true if eraser end is used (not all pens support this).  }
+      down: Boolean;                  {*< true if the pen is touching or false if the pen is lifted off  }
     end;
 
 {*
@@ -817,7 +817,7 @@ type
       x: cfloat;                      {*< X coordinate, relative to window  }
       y: cfloat;                      {*< Y coordinate, relative to window  }
       button: cuint8;                 {*< The pen button index (first button is 1).  }
-      down: cbool;                    {*< true if the button is pressed  }
+      down: Boolean;                  {*< true if the button is pressed  }
     end;
 
 {*
@@ -874,7 +874,7 @@ type
       type_: TSDL_EventType;  {*< SDL_EVENT_CLIPBOARD_UPDATE  }
       reserved: cuint32;
       timestamp: cuint64;     {*< In nanoseconds, populated using SDL_GetTicksNS()  }
-      owner: cbool;           {*< are we owning the clipboard (internal update)  }
+      owner: Boolean;         {*< are we owning the clipboard (internal update)  }
       n_mime_types: cint32;   {*< number of mime types  }
       mime_types: ^PAnsiChar; {*< current mime types  }
     end;
@@ -1104,7 +1104,7 @@ function SDL_PeepEvents(events: PSDL_Event; numevents: cint; action: TSDL_EventA
  *
  * \sa SDL_HasEvents
   }
-function SDL_HasEvent(type_: cuint32): cbool; cdecl;
+function SDL_HasEvent(type_: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasEvent' {$ENDIF} {$ENDIF};
 
 {*
@@ -1125,7 +1125,7 @@ function SDL_HasEvent(type_: cuint32): cbool; cdecl;
  *
  * \sa SDL_HasEvents
   }
-function SDL_HasEvents(minType: cuint32; maxType: cuint32): cbool; cdecl;
+function SDL_HasEvents(minType: cuint32; maxType: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasEvents' {$ENDIF} {$ENDIF};
 
 {*
@@ -1231,7 +1231,7 @@ procedure SDL_FlushEvents(minType: cuint32; maxType: cuint32); cdecl;
  * \sa SDL_WaitEvent
  * \sa SDL_WaitEventTimeout
   }
-function SDL_PollEvent(event: PSDL_Event): cbool; cdecl;
+function SDL_PollEvent(event: PSDL_Event): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PollEvent' {$ENDIF} {$ENDIF};
 
 {*
@@ -1258,7 +1258,7 @@ function SDL_PollEvent(event: PSDL_Event): cbool; cdecl;
  * \sa SDL_PushEvent
  * \sa SDL_WaitEventTimeout
   }
-function SDL_WaitEvent(event: PSDL_Event): cbool; cdecl;
+function SDL_WaitEvent(event: PSDL_Event): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitEvent' {$ENDIF} {$ENDIF};
 
 {*
@@ -1291,7 +1291,7 @@ function SDL_WaitEvent(event: PSDL_Event): cbool; cdecl;
  * \sa SDL_PushEvent
  * \sa SDL_WaitEvent
   }
-function SDL_WaitEventTimeout(event: PSDL_Event; timeoutMS: cint32): cbool; cdecl;
+function SDL_WaitEventTimeout(event: PSDL_Event; timeoutMS: cint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitEventTimeout' {$ENDIF} {$ENDIF};
 
 {*
@@ -1326,7 +1326,7 @@ function SDL_WaitEventTimeout(event: PSDL_Event; timeoutMS: cint32): cbool; cdec
  * \sa SDL_PollEvent
  * \sa SDL_RegisterEvents
   }
-function SDL_PushEvent(event: PSDL_Event): cbool; cdecl;
+function SDL_PushEvent(event: PSDL_Event): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PushEvent' {$ENDIF} {$ENDIF};
 
 {*
@@ -1350,7 +1350,7 @@ function SDL_PushEvent(event: PSDL_Event): cbool; cdecl;
   }
 type
   PSDL_EventFilter = ^TSDL_EventFilter;
-  TSDL_EventFilter = function (userdata: Pointer; event: PSDL_Event): cbool; cdecl;
+  TSDL_EventFilter = function (userdata: Pointer; event: PSDL_Event): Boolean; cdecl;
 
 {*
  * Set up a filter to process all events before they change internal state and
@@ -1416,7 +1416,7 @@ procedure SDL_SetEventFilter(filter: TSDL_EventFilter; userdata: Pointer); cdecl
  *
  * \sa SDL_SetEventFilter
   }
-function SDL_GetEventFilter(filter: PSDL_EventFilter; userdata: PPointer): cbool; cdecl;
+function SDL_GetEventFilter(filter: PSDL_EventFilter; userdata: PPointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetEventFilter' {$ENDIF} {$ENDIF};
 
 {*
@@ -1449,7 +1449,7 @@ function SDL_GetEventFilter(filter: PSDL_EventFilter; userdata: PPointer): cbool
  * \sa SDL_RemoveEventWatch
  * \sa SDL_SetEventFilter
   }
-function SDL_AddEventWatch(filter: TSDL_EventFilter; userdata: Pointer): cbool; cdecl;
+function SDL_AddEventWatch(filter: TSDL_EventFilter; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AddEventWatch' {$ENDIF} {$ENDIF};
 
 {*
@@ -1503,7 +1503,7 @@ procedure SDL_FilterEvents(filter: TSDL_EventFilter; userdata: Pointer); cdecl;
  *
  * \sa SDL_EventEnabled
   }
-procedure SDL_SetEventEnabled(type_: cuint32; enabled: cbool); cdecl;
+procedure SDL_SetEventEnabled(type_: cuint32; enabled: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetEventEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1518,7 +1518,7 @@ procedure SDL_SetEventEnabled(type_: cuint32; enabled: cbool); cdecl;
  *
  * \sa SDL_SetEventEnabled
   }
-function SDL_EventEnabled(type_: cuint32): cbool; cdecl;
+function SDL_EventEnabled(type_: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EventEnabled' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_filesystem.inc
+++ b/units/SDL_filesystem.inc
@@ -270,7 +270,7 @@ const
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_CreateDirectory(path: PAnsiChar): cbool; cdecl;
+function SDL_CreateDirectory(path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CreateDirectory' {$ENDIF} {$ENDIF};
 
 {*
@@ -337,7 +337,7 @@ type
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_EnumerateDirectory(path: PAnsiChar; callback: TSDL_EnumerateDirectoryCallback; userdata: Pointer): cbool; cdecl;
+function SDL_EnumerateDirectory(path: PAnsiChar; callback: TSDL_EnumerateDirectoryCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EnumerateDirectory' {$ENDIF} {$ENDIF};
 
 {*
@@ -352,7 +352,7 @@ function SDL_EnumerateDirectory(path: PAnsiChar; callback: TSDL_EnumerateDirecto
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_RemovePath(path: PAnsiChar): cbool; cdecl;
+function SDL_RemovePath(path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RemovePath' {$ENDIF} {$ENDIF};
 
 {*
@@ -376,7 +376,7 @@ function SDL_RemovePath(path: PAnsiChar): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_RenamePath(oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
+function SDL_RenamePath(oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenamePath' {$ENDIF} {$ENDIF};
 
 {*
@@ -417,7 +417,7 @@ function SDL_RenamePath(oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_CopyFile(oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
+function SDL_CopyFile(oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CopyFile' {$ENDIF} {$ENDIF};
 
 {*
@@ -431,7 +431,7 @@ function SDL_CopyFile(oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GetPathInfo(path: PAnsiChar; info: PSDL_PathInfo): cbool; cdecl;
+function SDL_GetPathInfo(path: PAnsiChar; info: PSDL_PathInfo): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetPathInfo' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_gamepad.inc
+++ b/units/SDL_gamepad.inc
@@ -350,7 +350,7 @@ function SDL_AddGamepadMapping(mapping: PAnsiChar): cint; cdecl;
  * \sa SDL_HINT_GAMECONTROLLERCONFIG_FILE
  * \sa SDL_EVENT_GAMEPAD_ADDED
   }
-function SDL_AddGamepadMappingsFromIO(src: PSDL_IOStream; closeio: cbool): cint; cdecl;
+function SDL_AddGamepadMappingsFromIO(src: PSDL_IOStream; closeio: Boolean): cint; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AddGamepadMappingsFromIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -398,7 +398,7 @@ function SDL_AddGamepadMappingsFromFile(file_: PAnsiChar): cint; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReloadGamepadMappings: cbool; cdecl;
+function SDL_ReloadGamepadMappings: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReloadGamepadMappings' {$ENDIF} {$ENDIF};
 
 {*
@@ -468,7 +468,7 @@ function SDL_GetGamepadMapping(gamepad: PSDL_Gamepad): PAnsiChar; cdecl;
  * \sa SDL_AddGamepadMapping
  * \sa SDL_GetGamepadMapping
   }
-function SDL_SetGamepadMapping(instance_id: TSDL_JoystickID; mapping: PAnsiChar): cbool; cdecl;
+function SDL_SetGamepadMapping(instance_id: TSDL_JoystickID; mapping: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGamepadMapping' {$ENDIF} {$ENDIF};
 
 {*
@@ -480,7 +480,7 @@ function SDL_SetGamepadMapping(instance_id: TSDL_JoystickID; mapping: PAnsiChar)
  *
  * \sa SDL_GetGamepads
   }
-function SDL_HasGamepad: cbool; cdecl;
+function SDL_HasGamepad: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasGamepad' {$ENDIF} {$ENDIF};
 
 {*
@@ -512,7 +512,7 @@ function SDL_GetGamepads(count: pcint): PSDL_JoystickID; cdecl;
  * \sa SDL_GetJoysticks
  * \sa SDL_OpenGamepad
   }
-function SDL_IsGamepad(instance_id: TSDL_JoystickID): cbool; cdecl;
+function SDL_IsGamepad(instance_id: TSDL_JoystickID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IsGamepad' {$ENDIF} {$ENDIF};
 
 {*
@@ -865,7 +865,7 @@ function SDL_GetGamepadPlayerIndex(gamepad: PSDL_Gamepad): cint; cdecl;
  *
  * \sa SDL_GetGamepadPlayerIndex
   }
-function SDL_SetGamepadPlayerIndex(gamepad: PSDL_Gamepad; player_index: cint): cbool; cdecl;
+function SDL_SetGamepadPlayerIndex(gamepad: PSDL_Gamepad; player_index: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGamepadPlayerIndex' {$ENDIF} {$ENDIF};
 
 {*
@@ -997,7 +997,7 @@ function SDL_GetGamepadPowerInfo(gamepad: PSDL_Gamepad; percent: pcint): TSDL_Po
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GamepadConnected(gamepad: PSDL_Gamepad): cbool; cdecl;
+function SDL_GamepadConnected(gamepad: PSDL_Gamepad): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadConnected' {$ENDIF} {$ENDIF};
 
 {*
@@ -1034,7 +1034,7 @@ function SDL_GetGamepadJoystick(gamepad: PSDL_Gamepad): PSDL_Joystick; cdecl;
  * \sa SDL_GamepadEventsEnabled
  * \sa SDL_UpdateGamepads
   }
-procedure SDL_SetGamepadEventsEnabled(enabled: cbool); cdecl;
+procedure SDL_SetGamepadEventsEnabled(enabled: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGamepadEventsEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1049,7 +1049,7 @@ procedure SDL_SetGamepadEventsEnabled(enabled: cbool); cdecl;
  *
  * \sa SDL_SetGamepadEventsEnabled
   }
-function SDL_GamepadEventsEnabled: cbool; cdecl;
+function SDL_GamepadEventsEnabled: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadEventsEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1166,7 +1166,7 @@ function SDL_GetGamepadStringForAxis(axis: TSDL_GamepadAxis): PAnsiChar; cdecl;
  * \sa SDL_GamepadHasButton
  * \sa SDL_GetGamepadAxis
   }
-function SDL_GamepadHasAxis(gamepad: PSDL_Gamepad; axis: TSDL_GamepadAxis): cbool; cdecl;
+function SDL_GamepadHasAxis(gamepad: PSDL_Gamepad; axis: TSDL_GamepadAxis): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadHasAxis' {$ENDIF} {$ENDIF};
 
 {*
@@ -1242,7 +1242,7 @@ function SDL_GetGamepadStringForButton(button: TSDL_GamepadButton): PAnsiChar; c
  *
  * \sa SDL_GamepadHasAxis
   }
-function SDL_GamepadHasButton(gamepad: PSDL_Gamepad; button: TSDL_GamepadButton): cbool; cdecl;
+function SDL_GamepadHasButton(gamepad: PSDL_Gamepad; button: TSDL_GamepadButton): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadHasButton' {$ENDIF} {$ENDIF};
 
 {*
@@ -1257,7 +1257,7 @@ function SDL_GamepadHasButton(gamepad: PSDL_Gamepad; button: TSDL_GamepadButton)
  * \sa SDL_GamepadHasButton
  * \sa SDL_GetGamepadAxis
   }
-function SDL_GetGamepadButton(gamepad: PSDL_Gamepad; button: TSDL_GamepadButton): cbool; cdecl;
+function SDL_GetGamepadButton(gamepad: PSDL_Gamepad; button: TSDL_GamepadButton): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetGamepadButton' {$ENDIF} {$ENDIF};
 
 {*
@@ -1337,7 +1337,7 @@ function SDL_GetNumGamepadTouchpadFingers(gamepad: PSDL_Gamepad; touchpad: cint)
  *
  * \sa SDL_GetNumGamepadTouchpadFingers
   }
-function SDL_GetGamepadTouchpadFinger(gamepad: PSDL_Gamepad; touchpad: cint; finger: cint; down: pcbool; x: pcfloat; y: pcfloat; pressure: pcfloat): cbool; cdecl;
+function SDL_GetGamepadTouchpadFinger(gamepad: PSDL_Gamepad; touchpad: cint; finger: cint; down: pBoolean; x: pcfloat; y: pcfloat; pressure: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetGamepadTouchpadFinger' {$ENDIF} {$ENDIF};
 
 {*
@@ -1353,7 +1353,7 @@ function SDL_GetGamepadTouchpadFinger(gamepad: PSDL_Gamepad; touchpad: cint; fin
  * \sa SDL_GetGamepadSensorDataRate
  * \sa SDL_SetGamepadSensorEnabled
   }
-function SDL_GamepadHasSensor(gamepad: PSDL_Gamepad; type_: TSDL_SensorType): cbool; cdecl;
+function SDL_GamepadHasSensor(gamepad: PSDL_Gamepad; type_: TSDL_SensorType): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadHasSensor' {$ENDIF} {$ENDIF};
 
 {*
@@ -1370,7 +1370,7 @@ function SDL_GamepadHasSensor(gamepad: PSDL_Gamepad; type_: TSDL_SensorType): cb
  * \sa SDL_GamepadHasSensor
  * \sa SDL_GamepadSensorEnabled
   }
-function SDL_SetGamepadSensorEnabled(gamepad: PSDL_Gamepad; type_: TSDL_SensorType; enabled: cbool): cbool; cdecl;
+function SDL_SetGamepadSensorEnabled(gamepad: PSDL_Gamepad; type_: TSDL_SensorType; enabled: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGamepadSensorEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1384,7 +1384,7 @@ function SDL_SetGamepadSensorEnabled(gamepad: PSDL_Gamepad; type_: TSDL_SensorTy
  *
  * \sa SDL_SetGamepadSensorEnabled
   }
-function SDL_GamepadSensorEnabled(gamepad: PSDL_Gamepad; type_: TSDL_SensorType): cbool; cdecl;
+function SDL_GamepadSensorEnabled(gamepad: PSDL_Gamepad; type_: TSDL_SensorType): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GamepadSensorEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1414,7 +1414,7 @@ function SDL_GetGamepadSensorDataRate(gamepad: PSDL_Gamepad; type_: TSDL_SensorT
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GetGamepadSensorData(gamepad: PSDL_Gamepad; type_: TSDL_SensorType; data: pcfloat; num_values: cint): cbool; cdecl;
+function SDL_GetGamepadSensorData(gamepad: PSDL_Gamepad; type_: TSDL_SensorType; data: pcfloat; num_values: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetGamepadSensorData' {$ENDIF} {$ENDIF};
 
 {*
@@ -1437,7 +1437,7 @@ function SDL_GetGamepadSensorData(gamepad: PSDL_Gamepad; type_: TSDL_SensorType;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_RumbleGamepad(gamepad: PSDL_Gamepad; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16; duration_ms: cuint32): cbool; cdecl;
+function SDL_RumbleGamepad(gamepad: PSDL_Gamepad; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16; duration_ms: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RumbleGamepad' {$ENDIF} {$ENDIF};
 
 {*
@@ -1466,7 +1466,7 @@ function SDL_RumbleGamepad(gamepad: PSDL_Gamepad; low_frequency_rumble: cuint16;
  *
  * \sa SDL_RumbleGamepad
   }
-function SDL_RumbleGamepadTriggers(gamepad: PSDL_Gamepad; left_rumble: cuint16; right_rumble: cuint16; duration_ms: cuint32): cbool; cdecl;
+function SDL_RumbleGamepadTriggers(gamepad: PSDL_Gamepad; left_rumble: cuint16; right_rumble: cuint16; duration_ms: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RumbleGamepadTriggers' {$ENDIF} {$ENDIF};
 
 {*
@@ -1487,7 +1487,7 @@ function SDL_RumbleGamepadTriggers(gamepad: PSDL_Gamepad; left_rumble: cuint16; 
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_SetGamepadLED(gamepad: PSDL_Gamepad; red: cuint8; green: cuint8; blue: cuint8): cbool; cdecl;
+function SDL_SetGamepadLED(gamepad: PSDL_Gamepad; red: cuint8; green: cuint8; blue: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGamepadLED' {$ENDIF} {$ENDIF};
 
 {*
@@ -1501,7 +1501,7 @@ function SDL_SetGamepadLED(gamepad: PSDL_Gamepad; red: cuint8; green: cuint8; bl
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_SendGamepadEffect(gamepad: PSDL_Gamepad; data: Pointer; size: cint): cbool; cdecl;
+function SDL_SendGamepadEffect(gamepad: PSDL_Gamepad; data: Pointer; size: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SendGamepadEffect' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_gpu.inc
+++ b/units/SDL_gpu.inc
@@ -1584,8 +1584,8 @@ type
       compare_op: TSDL_GPUCompareOp;               {*< The comparison operator to apply to fetched data before filtering.  }
       min_lod: cfloat;                             {*< Clamps the minimum of the computed LOD value.  }
       max_lod: cfloat;                             {*< Clamps the maximum of the computed LOD value.  }
-      enable_anisotropy: cbool;                    {*< true to enable anisotropic filtering.  }
-      enable_compare: cbool;                       {*< true to enable comparison against a reference value during lookups.  }
+      enable_anisotropy: Boolean;                  {*< true to enable anisotropic filtering.  }
+      enable_compare: Boolean;                     {*< true to enable comparison against a reference value during lookups.  }
       padding1: cuint8;
       padding2: cuint8;
 
@@ -1696,8 +1696,8 @@ type
       dst_alpha_blendfactor: TSDL_GPUBlendFactor;    {*< The value to be multiplied by the destination alpha.  }
       alpha_blend_op: TSDL_GPUBlendOp;               {*< The blend operation for the alpha component.  }
       color_write_mask: TSDL_GPUColorComponentFlags; {*< A bitmask specifying which of the RGBA components are enabled for writing. Writes to all channels if enable_color_write_mask is false.  }
-      enable_blend: cbool;                           {*< Whether blending is enabled for the color target.  }
-      enable_color_write_mask: cbool;                {*< Whether the color write mask is enabled.  }
+      enable_blend: Boolean;                         {*< Whether blending is enabled for the color target.  }
+      enable_color_write_mask: Boolean;              {*< Whether the color write mask is enabled.  }
       padding1: cuint8;
       padding2: cuint8;
     end;
@@ -1820,8 +1820,8 @@ type
       depth_bias_constant_factor: cfloat;  {*< A scalar factor controlling the depth value added to each fragment.  }
       depth_bias_clamp: cfloat;            {*< The maximum depth bias of a fragment.  }
       depth_bias_slope_factor: cfloat;     {*< A scalar factor applied to a fragment's slope in depth calculations.  }
-      enable_depth_bias: cbool;            {*< true to bias fragment depth values.  }
-      enable_depth_clip: cbool;            {*< true to enable depth clip, false to enable depth clamp.  }
+      enable_depth_bias: Boolean;          {*< true to bias fragment depth values.  }
+      enable_depth_clip: Boolean;          {*< true to enable depth clip, false to enable depth clamp.  }
       padding1: cuint8;
       padding2: cuint8;
     end;
@@ -1840,7 +1840,7 @@ type
   TSDL_GPUMultisampleState = record
       sample_count: TSDL_GPUSampleCount; {*< The number of samples to be used in rasterization.  }
       sample_mask: cuint32;              {*< Determines which samples get updated in the render targets. Treated as 0xFFFFFFFF if enable_mask is false.  }
-      enable_mask: cbool;                {*< Enables sample masking.  }
+      enable_mask: Boolean;              {*< Enables sample masking.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -1863,9 +1863,9 @@ type
       front_stencil_state: TSDL_GPUStencilOpState;  {*< The stencil op state for front-facing triangles.  }
       compare_mask: cuint8;                         {*< Selects the bits of the stencil values participating in the stencil test.  }
       write_mask: cuint8;                           {*< Selects the bits of the stencil values updated by the stencil test.  }
-      enable_depth_test: cbool;                     {*< true enables the depth test.  }
-      enable_depth_write: cbool;                    {*< true enables depth writes. Depth writes are always disabled when enable_depth_test is false.  }
-      enable_stencil_test: cbool;                   {*< true enables the stencil test.  }
+      enable_depth_test: Boolean;                   {*< true enables the depth test.  }
+      enable_depth_write: Boolean;                  {*< true enables depth writes. Depth writes are always disabled when enable_depth_test is false.  }
+      enable_stencil_test: Boolean;                 {*< true enables the stencil test.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -1902,7 +1902,7 @@ type
       color_target_descriptions: PSDL_GPUColorTargetDescription; {*< A Pointer to an array of color target descriptions.  }
       num_color_targets: cuint32;                                {*< The number of color target descriptions in the above array.  }
       depth_stencil_format: TSDL_GPUTextureFormat;               {*< The pixel format of the depth-stencil target. Ignored if has_depth_stencil_target is false.  }
-      has_depth_stencil_target: cbool;                           {*< true specifies that the pipeline uses a depth-stencil target.  }
+      has_depth_stencil_target: Boolean;                         {*< true specifies that the pipeline uses a depth-stencil target.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -2013,8 +2013,8 @@ type
       resolve_texture: PSDL_GPUTexture;  {*< The texture that will receive the results of a multisample resolve operation. Ignored if a RESOLVE* store_op is not used.  }
       resolve_mip_level: cuint32;        {*< The mip level of the resolve texture to use for the resolve operation. Ignored if a RESOLVE* store_op is not used.  }
       resolve_layer: cuint32;            {*< The layer index of the resolve texture to use for the resolve operation. Ignored if a RESOLVE* store_op is not used.  }
-      cycle: cbool;                      {*< true cycles the texture if the texture is bound and load_op is not LOAD  }
-      cycle_resolve_texture: cbool;      {*< true cycles the resolve texture if the resolve texture is bound. Ignored if a RESOLVE* store_op is not used.  }
+      cycle: Boolean;                    {*< true cycles the texture if the texture is bound and load_op is not LOAD  }
+      cycle_resolve_texture: Boolean;    {*< true cycles the resolve texture if the resolve texture is bound. Ignored if a RESOLVE* store_op is not used.  }
       padding1: cuint8;
       padding2: cuint8;
     end;
@@ -2073,7 +2073,7 @@ type
       store_op: TSDL_GPUStoreOp;          {*< What is done with the depth results of the render pass.  }
       stencil_load_op: TSDL_GPULoadOp;    {*< What is done with the stencil contents at the beginning of the render pass.  }
       stencil_store_op: TSDL_GPUStoreOp;  {*< What is done with the stencil results of the render pass.  }
-      cycle: cbool;                       {*< true cycles the texture if the texture is bound and any load ops are not LOAD  }
+      cycle: Boolean;                     {*< true cycles the texture if the texture is bound and any load ops are not LOAD  }
       clear_stencil: cuint8;              {*< The value to clear the stencil component to at the beginning of the render pass. Ignored if SDL_GPU_LOADOP_CLEAR is not used.  }
       padding1: cuint8;
       padding2: cuint8;
@@ -2096,7 +2096,7 @@ type
       clear_color: TSDL_FColor;         {*< The color to clear the destination region to before the blit. Ignored if load_op is not SDL_GPU_LOADOP_CLEAR.  }
       flip_mode: TSDL_FlipMode;         {*< The flip mode for the source region.  }
       filter: TSDL_GPUFilter;           {*< The filter mode used when blitting.  }
-      cycle: cbool;                     {*< true cycles the destination texture if it is already bound.  }
+      cycle: Boolean;                   {*< true cycles the destination texture if it is already bound.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -2149,7 +2149,7 @@ type
   PSDL_GPUStorageBufferReadWriteBinding = ^TSDL_GPUStorageBufferReadWriteBinding;
   TSDL_GPUStorageBufferReadWriteBinding = record
       buffer: PSDL_GPUBuffer;  {*< The buffer to bind. Must have been created with SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE.  }
-      cycle: cbool;            {*< true cycles the buffer if it is already bound.  }
+      cycle: Boolean;          {*< true cycles the buffer if it is already bound.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -2170,7 +2170,7 @@ type
       texture: PSDL_GPUTexture; {*< The texture to bind. Must have been created with SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE or SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE.  }
       mip_level: cuint32;       {*< The mip level index to bind.  }
       layer: cuint32;           {*< The layer index to bind.  }
-      cycle: cbool;             {*< true cycles the texture if it is already bound.  }
+      cycle: Boolean;           {*< true cycles the texture if it is already bound.  }
       padding1: cuint8;
       padding2: cuint8;
       padding3: cuint8;
@@ -2193,7 +2193,7 @@ type
  *
  * \sa SDL_CreateGPUDevice
   }
-function SDL_GPUSupportsShaderFormats(format_flags: TSDL_GPUShaderFormat; name: PAnsiChar): cbool; cdecl;
+function SDL_GPUSupportsShaderFormats(format_flags: TSDL_GPUShaderFormat; name: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GPUSupportsShaderFormats' {$ENDIF} {$ENDIF};
 
 {*
@@ -2206,7 +2206,7 @@ function SDL_GPUSupportsShaderFormats(format_flags: TSDL_GPUShaderFormat; name: 
  *
  * \sa SDL_CreateGPUDeviceWithProperties
   }
-function SDL_GPUSupportsProperties(props: TSDL_PropertiesID): cbool; cdecl;
+function SDL_GPUSupportsProperties(props: TSDL_PropertiesID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GPUSupportsProperties' {$ENDIF} {$ENDIF};
 
 {*
@@ -2227,7 +2227,7 @@ function SDL_GPUSupportsProperties(props: TSDL_PropertiesID): cbool; cdecl;
  * \sa SDL_DestroyGPUDevice
  * \sa SDL_GPUSupportsShaderFormats
   }
-function SDL_CreateGPUDevice(format_flags: TSDL_GPUShaderFormat; debug_mode: cbool; name: PAnsiChar): PSDL_GPUDevice; cdecl;
+function SDL_CreateGPUDevice(format_flags: TSDL_GPUShaderFormat; debug_mode: Boolean; name: PAnsiChar): PSDL_GPUDevice; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CreateGPUDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -3439,7 +3439,7 @@ procedure SDL_EndGPUComputePass(compute_pass: PSDL_GPUComputePass); cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_MapGPUTransferBuffer(device: PSDL_GPUDevice; transfer_buffer: PSDL_GPUTransferBuffer; cycle: cbool): Pointer; cdecl;
+function SDL_MapGPUTransferBuffer(device: PSDL_GPUDevice; transfer_buffer: PSDL_GPUTransferBuffer; cycle: Boolean): Pointer; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_MapGPUTransferBuffer' {$ENDIF} {$ENDIF};
 
 {*
@@ -3487,7 +3487,7 @@ function SDL_BeginGPUCopyPass(command_buffer: PSDL_GPUCommandBuffer): PSDL_GPUCo
  *
  * \since This function is available since SDL 3.2.0.
   }
-procedure SDL_UploadToGPUTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTextureTransferInfo; destination: PSDL_GPUTextureRegion; cycle: cbool); cdecl;
+procedure SDL_UploadToGPUTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTextureTransferInfo; destination: PSDL_GPUTextureRegion; cycle: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UploadToGPUTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -3504,7 +3504,7 @@ procedure SDL_UploadToGPUTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTe
  *
  * \since This function is available since SDL 3.2.0.
   }
-procedure SDL_UploadToGPUBuffer(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTransferBufferLocation; destination: PSDL_GPUBufferRegion; cycle: cbool); cdecl;
+procedure SDL_UploadToGPUBuffer(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTransferBufferLocation; destination: PSDL_GPUBufferRegion; cycle: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UploadToGPUBuffer' {$ENDIF} {$ENDIF};
 
 {*
@@ -3524,7 +3524,7 @@ procedure SDL_UploadToGPUBuffer(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTra
  *
  * \since This function is available since SDL 3.2.0.
   }
-procedure SDL_CopyGPUTextureToTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTextureLocation; destination: PSDL_GPUTextureLocation; w: cuint32; h: cuint32; d: cuint32; cycle: cbool); cdecl;
+procedure SDL_CopyGPUTextureToTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUTextureLocation; destination: PSDL_GPUTextureLocation; w: cuint32; h: cuint32; d: cuint32; cycle: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CopyGPUTextureToTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -3542,7 +3542,7 @@ procedure SDL_CopyGPUTextureToTexture(copy_pass: PSDL_GPUCopyPass; source: PSDL_
  *
  * \since This function is available since SDL 3.2.0.
   }
-procedure SDL_CopyGPUBufferToBuffer(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUBufferLocation; destination: PSDL_GPUBufferLocation; size: cuint32; cycle: cbool); cdecl;
+procedure SDL_CopyGPUBufferToBuffer(copy_pass: PSDL_GPUCopyPass; source: PSDL_GPUBufferLocation; destination: PSDL_GPUBufferLocation; size: cuint32; cycle: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CopyGPUBufferToBuffer' {$ENDIF} {$ENDIF};
 
 {*
@@ -3629,7 +3629,7 @@ procedure SDL_BlitGPUTexture(command_buffer: PSDL_GPUCommandBuffer; info: PSDL_G
  *
  * \sa SDL_ClaimWindowForGPUDevice
   }
-function SDL_WindowSupportsGPUSwapchainComposition(device: PSDL_GPUDevice; window: PSDL_Window; swapchain_composition: TSDL_GPUSwapchainComposition): cbool; cdecl;
+function SDL_WindowSupportsGPUSwapchainComposition(device: PSDL_GPUDevice; window: PSDL_Window; swapchain_composition: TSDL_GPUSwapchainComposition): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WindowSupportsGPUSwapchainComposition' {$ENDIF} {$ENDIF};
 
 {*
@@ -3646,7 +3646,7 @@ function SDL_WindowSupportsGPUSwapchainComposition(device: PSDL_GPUDevice; windo
  *
  * \sa SDL_ClaimWindowForGPUDevice
   }
-function SDL_WindowSupportsGPUPresentMode(device: PSDL_GPUDevice; window: PSDL_Window; present_mode: TSDL_GPUPresentMode): cbool; cdecl;
+function SDL_WindowSupportsGPUPresentMode(device: PSDL_GPUDevice; window: PSDL_Window; present_mode: TSDL_GPUPresentMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WindowSupportsGPUPresentMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -3676,7 +3676,7 @@ function SDL_WindowSupportsGPUPresentMode(device: PSDL_GPUDevice; window: PSDL_W
  * \sa SDL_WindowSupportsGPUPresentMode
  * \sa SDL_WindowSupportsGPUSwapchainComposition
   }
-function SDL_ClaimWindowForGPUDevice(device: PSDL_GPUDevice; window: PSDL_Window): cbool; cdecl;
+function SDL_ClaimWindowForGPUDevice(device: PSDL_GPUDevice; window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClaimWindowForGPUDevice' {$ENDIF} {$ENDIF};
 
 {*
@@ -3715,7 +3715,7 @@ procedure SDL_ReleaseWindowFromGPUDevice(device: PSDL_GPUDevice; window: PSDL_Wi
  * \sa SDL_WindowSupportsGPUPresentMode
  * \sa SDL_WindowSupportsGPUSwapchainComposition
   }
-function SDL_SetGPUSwapchainParameters(device: PSDL_GPUDevice; window: PSDL_Window; swapchain_composition: TSDL_GPUSwapchainComposition; present_mode: TSDL_GPUPresentMode): cbool; cdecl;
+function SDL_SetGPUSwapchainParameters(device: PSDL_GPUDevice; window: PSDL_Window; swapchain_composition: TSDL_GPUSwapchainComposition; present_mode: TSDL_GPUPresentMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGPUSwapchainParameters' {$ENDIF} {$ENDIF};
 
 {*
@@ -3743,7 +3743,7 @@ function SDL_SetGPUSwapchainParameters(device: PSDL_GPUDevice; window: PSDL_Wind
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_SetGPUAllowedFramesInFlight(device: PSDL_GPUDevice; allowed_frames_in_flight: cuint32): cbool; cdecl;
+function SDL_SetGPUAllowedFramesInFlight(device: PSDL_GPUDevice; allowed_frames_in_flight: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetGPUAllowedFramesInFlight' {$ENDIF} {$ENDIF};
 
 {*
@@ -3806,7 +3806,7 @@ function SDL_GetGPUSwapchainTextureFormat(device: PSDL_GPUDevice; window: PSDL_W
  * \sa SDL_WaitAndAcquireGPUSwapchainTexture
  * \sa SDL_SetGPUAllowedFramesInFlight
   }
-function SDL_AcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBuffer; window: PSDL_Window; swapchain_texture: PPSDL_GPUTexture; swapchain_texture_width: pcuint32; swapchain_texture_height: pcuint32): cbool; cdecl;
+function SDL_AcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBuffer; window: PSDL_Window; swapchain_texture: PPSDL_GPUTexture; swapchain_texture_width: pcuint32; swapchain_texture_height: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AcquireGPUSwapchainTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -3826,7 +3826,7 @@ function SDL_AcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBuffer; w
  * \sa SDL_WaitAndAcquireGPUSwapchainTexture
  * \sa SDL_SetGPUAllowedFramesInFlight
   }
-function SDL_WaitForGPUSwapchain(device: PSDL_GPUDevice; window: PSDL_Window): cbool; cdecl;
+function SDL_WaitForGPUSwapchain(device: PSDL_GPUDevice; window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitForGPUSwapchain' {$ENDIF} {$ENDIF};
 
 {*
@@ -3867,7 +3867,7 @@ function SDL_WaitForGPUSwapchain(device: PSDL_GPUDevice; window: PSDL_Window): c
  * \sa SDL_SubmitGPUCommandBuffer
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
   }
-function SDL_WaitAndAcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBuffer; window: PSDL_Window; swapchain_texture: PPSDL_GPUTexture; swapchain_texture_width: pcuint32; swapchain_texture_height: pcuint32): cbool; cdecl;
+function SDL_WaitAndAcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBuffer; window: PSDL_Window; swapchain_texture: PPSDL_GPUTexture; swapchain_texture_width: pcuint32; swapchain_texture_height: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitAndAcquireGPUSwapchainTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -3891,7 +3891,7 @@ function SDL_WaitAndAcquireGPUSwapchainTexture(command_buffer: PSDL_GPUCommandBu
  * \sa SDL_AcquireGPUSwapchainTexture
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
   }
-function SDL_SubmitGPUCommandBuffer(command_buffer: PSDL_GPUCommandBuffer): cbool; cdecl;
+function SDL_SubmitGPUCommandBuffer(command_buffer: PSDL_GPUCommandBuffer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SubmitGPUCommandBuffer' {$ENDIF} {$ENDIF};
 
 {*
@@ -3943,7 +3943,7 @@ function SDL_SubmitGPUCommandBufferAndAcquireFence(command_buffer: PSDL_GPUComma
  * \sa SDL_AcquireGPUCommandBuffer
  * \sa SDL_AcquireGPUSwapchainTexture
   }
-function SDL_CancelGPUCommandBuffer(command_buffer: PSDL_GPUCommandBuffer): cbool; cdecl;
+function SDL_CancelGPUCommandBuffer(command_buffer: PSDL_GPUCommandBuffer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CancelGPUCommandBuffer' {$ENDIF} {$ENDIF};
 
 {*
@@ -3957,7 +3957,7 @@ function SDL_CancelGPUCommandBuffer(command_buffer: PSDL_GPUCommandBuffer): cboo
  *
  * \sa SDL_WaitForGPUFences
   }
-function SDL_WaitForGPUIdle(device: PSDL_GPUDevice): cbool; cdecl;
+function SDL_WaitForGPUIdle(device: PSDL_GPUDevice): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitForGPUIdle' {$ENDIF} {$ENDIF};
 
 {*
@@ -3976,7 +3976,7 @@ function SDL_WaitForGPUIdle(device: PSDL_GPUDevice): cbool; cdecl;
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
  * \sa SDL_WaitForGPUIdle
   }
-function SDL_WaitForGPUFences(device: PSDL_GPUDevice; wait_all: cbool; fences: PPSDL_GPUFence; num_fences: cuint32): cbool; cdecl;
+function SDL_WaitForGPUFences(device: PSDL_GPUDevice; wait_all: Boolean; fences: PPSDL_GPUFence; num_fences: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitForGPUFences' {$ENDIF} {$ENDIF};
 
 {*
@@ -3990,7 +3990,7 @@ function SDL_WaitForGPUFences(device: PSDL_GPUDevice; wait_all: cbool; fences: P
  *
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
   }
-function SDL_QueryGPUFence(device: PSDL_GPUDevice; fence: PSDL_GPUFence): cbool; cdecl;
+function SDL_QueryGPUFence(device: PSDL_GPUDevice; fence: PSDL_GPUFence): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_QueryGPUFence' {$ENDIF} {$ENDIF};
 
 {*
@@ -4033,7 +4033,7 @@ function SDL_GPUTextureFormatTexelBlockSize(format: TSDL_GPUTextureFormat): cuin
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GPUTextureSupportsFormat(device: PSDL_GPUDevice; format: TSDL_GPUTextureFormat; type_: TSDL_GPUTextureType; usage: TSDL_GPUTextureUsageFlags): cbool; cdecl;
+function SDL_GPUTextureSupportsFormat(device: PSDL_GPUDevice; format: TSDL_GPUTextureFormat; type_: TSDL_GPUTextureType; usage: TSDL_GPUTextureUsageFlags): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GPUTextureSupportsFormat' {$ENDIF} {$ENDIF};
 
 {*
@@ -4046,7 +4046,7 @@ function SDL_GPUTextureSupportsFormat(device: PSDL_GPUDevice; format: TSDL_GPUTe
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GPUTextureSupportsSampleCount(device: PSDL_GPUDevice; format: TSDL_GPUTextureFormat; sample_count: TSDL_GPUSampleCount): cbool; cdecl;
+function SDL_GPUTextureSupportsSampleCount(device: PSDL_GPUDevice; format: TSDL_GPUTextureFormat; sample_count: TSDL_GPUSampleCount): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GPUTextureSupportsSampleCount' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_haptic.inc
+++ b/units/SDL_haptic.inc
@@ -1036,7 +1036,7 @@ function SDL_GetHapticName(haptic: PSDL_Haptic): PAnsiChar; cdecl;
  *
  * \sa SDL_OpenHapticFromMouse
   }
-function SDL_IsMouseHaptic: cbool; cdecl;
+function SDL_IsMouseHaptic: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IsMouseHaptic' {$ENDIF} {$ENDIF};
 
 {*
@@ -1063,7 +1063,7 @@ function SDL_OpenHapticFromMouse: PSDL_Haptic; cdecl;
  *
  * \sa SDL_OpenHapticFromJoystick
   }
-function SDL_IsJoystickHaptic(joystick: PSDL_Joystick): cbool; cdecl;
+function SDL_IsJoystickHaptic(joystick: PSDL_Joystick): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IsJoystickHaptic' {$ENDIF} {$ENDIF};
 
 {*
@@ -1179,7 +1179,7 @@ function SDL_GetNumHapticAxes(haptic: PSDL_Haptic): cint; cdecl;
  * \sa SDL_CreateHapticEffect
  * \sa SDL_GetHapticFeatures
   }
-function SDL_HapticEffectSupported(haptic: PSDL_Haptic; effect: PSDL_HapticEffect): cbool; cdecl;
+function SDL_HapticEffectSupported(haptic: PSDL_Haptic; effect: PSDL_HapticEffect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HapticEffectSupported' {$ENDIF} {$ENDIF};
 
 {*
@@ -1220,7 +1220,7 @@ function SDL_CreateHapticEffect(haptic: PSDL_Haptic; effect: PSDL_HapticEffect):
  * \sa SDL_CreateHapticEffect
  * \sa SDL_RunHapticEffect
   }
-function SDL_UpdateHapticEffect(haptic: PSDL_Haptic; effect: cint; data: PSDL_HapticEffect): cbool; cdecl;
+function SDL_UpdateHapticEffect(haptic: PSDL_Haptic; effect: cint; data: PSDL_HapticEffect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateHapticEffect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1245,7 +1245,7 @@ function SDL_UpdateHapticEffect(haptic: PSDL_Haptic; effect: cint; data: PSDL_Ha
  * \sa SDL_StopHapticEffect
  * \sa SDL_StopHapticEffects
   }
-function SDL_RunHapticEffect(haptic: PSDL_Haptic; effect: cint; iterations: cuint32): cbool; cdecl;
+function SDL_RunHapticEffect(haptic: PSDL_Haptic; effect: cint; iterations: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RunHapticEffect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1261,7 +1261,7 @@ function SDL_RunHapticEffect(haptic: PSDL_Haptic; effect: cint; iterations: cuin
  * \sa SDL_RunHapticEffect
  * \sa SDL_StopHapticEffects
   }
-function SDL_StopHapticEffect(haptic: PSDL_Haptic; effect: cint): cbool; cdecl;
+function SDL_StopHapticEffect(haptic: PSDL_Haptic; effect: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StopHapticEffect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1294,7 +1294,7 @@ procedure SDL_DestroyHapticEffect(haptic: PSDL_Haptic; effect: cint); cdecl;
  *
  * \sa SDL_GetHapticFeatures
   }
-function SDL_GetHapticEffectStatus(haptic: PSDL_Haptic; effect: cint): cbool; cdecl;
+function SDL_GetHapticEffectStatus(haptic: PSDL_Haptic; effect: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetHapticEffectStatus' {$ENDIF} {$ENDIF};
 
 {*
@@ -1317,7 +1317,7 @@ function SDL_GetHapticEffectStatus(haptic: PSDL_Haptic; effect: cint): cbool; cd
  *
  * \sa SDL_GetHapticFeatures
   }
-function SDL_SetHapticGain(haptic: PSDL_Haptic; gain: cint): cbool; cdecl;
+function SDL_SetHapticGain(haptic: PSDL_Haptic; gain: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetHapticGain' {$ENDIF} {$ENDIF};
 
 {*
@@ -1337,7 +1337,7 @@ function SDL_SetHapticGain(haptic: PSDL_Haptic; gain: cint): cbool; cdecl;
  *
  * \sa SDL_GetHapticFeatures
   }
-function SDL_SetHapticAutocenter(haptic: PSDL_Haptic; autocenter: cint): cbool; cdecl;
+function SDL_SetHapticAutocenter(haptic: PSDL_Haptic; autocenter: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetHapticAutocenter' {$ENDIF} {$ENDIF};
 
 {*
@@ -1357,7 +1357,7 @@ function SDL_SetHapticAutocenter(haptic: PSDL_Haptic; autocenter: cint): cbool; 
  *
  * \sa SDL_ResumeHaptic
   }
-function SDL_PauseHaptic(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_PauseHaptic(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PauseHaptic' {$ENDIF} {$ENDIF};
 
 {*
@@ -1373,7 +1373,7 @@ function SDL_PauseHaptic(haptic: PSDL_Haptic): cbool; cdecl;
  *
  * \sa SDL_PauseHaptic
   }
-function SDL_ResumeHaptic(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_ResumeHaptic(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ResumeHaptic' {$ENDIF} {$ENDIF};
 
 {*
@@ -1388,7 +1388,7 @@ function SDL_ResumeHaptic(haptic: PSDL_Haptic): cbool; cdecl;
  * \sa SDL_RunHapticEffect
  * \sa SDL_StopHapticEffects
   }
-function SDL_StopHapticEffects(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_StopHapticEffects(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StopHapticEffects' {$ENDIF} {$ENDIF};
 
 {*
@@ -1401,7 +1401,7 @@ function SDL_StopHapticEffects(haptic: PSDL_Haptic): cbool; cdecl;
  *
  * \sa SDL_InitHapticRumble
   }
-function SDL_HapticRumbleSupported(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_HapticRumbleSupported(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HapticRumbleSupported' {$ENDIF} {$ENDIF};
 
 {*
@@ -1417,7 +1417,7 @@ function SDL_HapticRumbleSupported(haptic: PSDL_Haptic): cbool; cdecl;
  * \sa SDL_StopHapticRumble
  * \sa SDL_HapticRumbleSupported
   }
-function SDL_InitHapticRumble(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_InitHapticRumble(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_InitHapticRumble' {$ENDIF} {$ENDIF};
 
 {*
@@ -1434,7 +1434,7 @@ function SDL_InitHapticRumble(haptic: PSDL_Haptic): cbool; cdecl;
  * \sa SDL_InitHapticRumble
  * \sa SDL_StopHapticRumble
   }
-function SDL_PlayHapticRumble(haptic: PSDL_Haptic; strength: cfloat; length: cuint32): cbool; cdecl;
+function SDL_PlayHapticRumble(haptic: PSDL_Haptic; strength: cfloat; length: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PlayHapticRumble' {$ENDIF} {$ENDIF};
 
 {*
@@ -1448,6 +1448,6 @@ function SDL_PlayHapticRumble(haptic: PSDL_Haptic; strength: cfloat; length: cui
  *
  * \sa SDL_PlayHapticRumble
   }
-function SDL_StopHapticRumble(haptic: PSDL_Haptic): cbool; cdecl;
+function SDL_StopHapticRumble(haptic: PSDL_Haptic): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StopHapticRumble' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_hidapi.inc
+++ b/units/SDL_hidapi.inc
@@ -514,6 +514,6 @@ function SDL_hid_get_report_descriptor(dev: PSDL_hid_device; buf: pcuchar; buf_s
  *
  * \since This function is available since SDL 3.2.0.
   }
-procedure SDL_hid_ble_scan(active: cbool); cdecl;
+procedure SDL_hid_ble_scan(active: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_hid_ble_scan' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_hints.inc
+++ b/units/SDL_hints.inc
@@ -4298,7 +4298,7 @@ const
  * \sa SDL_ResetHint
  * \sa SDL_SetHint
   }
-function SDL_SetHintWithPriority(name: PAnsiChar; value: PAnsiChar; priority: TSDL_HintPriority): cbool; cdecl;
+function SDL_SetHintWithPriority(name: PAnsiChar; value: PAnsiChar; priority: TSDL_HintPriority): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetHintWithPriority' {$ENDIF} {$ENDIF};
 
 {*
@@ -4321,7 +4321,7 @@ function SDL_SetHintWithPriority(name: PAnsiChar; value: PAnsiChar; priority: TS
  * \sa SDL_ResetHint
  * \sa SDL_SetHintWithPriority
   }
-function SDL_SetHint(name: PAnsiChar; value: PAnsiChar): cbool; cdecl;
+function SDL_SetHint(name: PAnsiChar; value: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetHint' {$ENDIF} {$ENDIF};
 
 {*
@@ -4342,7 +4342,7 @@ function SDL_SetHint(name: PAnsiChar; value: PAnsiChar): cbool; cdecl;
  * \sa SDL_SetHint
  * \sa SDL_ResetHints
   }
-function SDL_ResetHint(name: PAnsiChar): cbool; cdecl;
+function SDL_ResetHint(name: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ResetHint' {$ENDIF} {$ENDIF};
 
 {*
@@ -4397,8 +4397,8 @@ function SDL_GetHint(name: PAnsiChar): PAnsiChar; cdecl;
  * \sa SDL_GetHint
  * \sa SDL_SetHint
   }
-function SDL_GetHincboolean(name: PAnsiChar; default_value: cbool): cbool; cdecl;
-  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetHincboolean' {$ENDIF} {$ENDIF};
+function SDL_GetHinBooleanean(name: PAnsiChar; default_value: Boolean): Boolean; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetHinBooleanean' {$ENDIF} {$ENDIF};
 
 {*
  * A callback used to send notifications of hint value changes.
@@ -4441,7 +4441,7 @@ type
  *
  * \sa SDL_RemoveHintCallback
   }
-function SDL_AddHintCallback(name: PAnsiChar; callback: TSDL_HintCallback; userdata: Pointer): cbool; cdecl;
+function SDL_AddHintCallback(name: PAnsiChar; callback: TSDL_HintCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AddHintCallback' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_init.inc
+++ b/units/SDL_init.inc
@@ -155,7 +155,7 @@ type
  * \sa SDL_WasInit
   }
 
-function SDL_Init(flags: TSDL_InitFlags): cbool; cdecl;
+function SDL_Init(flags: TSDL_InitFlags): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_Init' {$ENDIF} {$ENDIF};
 
 {*
@@ -173,7 +173,7 @@ function SDL_Init(flags: TSDL_InitFlags): cbool; cdecl;
  * \sa SDL_Quit
  * \sa SDL_QuitSubSystem
   }
-function SDL_InitSubSystem(flags: TSDL_InitFlags): cbool; cdecl;
+function SDL_InitSubSystem(flags: TSDL_InitFlags): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_InitSubSystem' {$ENDIF} {$ENDIF};
 
 {*
@@ -262,7 +262,7 @@ procedure SDL_Quit; cdecl;
  *
  * \sa SDL_SetAppMetadataProperty
   }
-function SDL_SetAppMetadata(appname: PAnsiChar; appversion: PAnsiChar; appidentifier: PAnsiChar): cbool; cdecl;
+function SDL_SetAppMetadata(appname: PAnsiChar; appversion: PAnsiChar; appidentifier: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAppMetadata' {$ENDIF} {$ENDIF};
 
 {*
@@ -326,7 +326,7 @@ function SDL_SetAppMetadata(appname: PAnsiChar; appversion: PAnsiChar; appidenti
  * \sa SDL_GetAppMetadataProperty
  * \sa SDL_SetAppMetadata
   }
-function SDL_SetAppMetadataProperty(name: PAnsiChar; value: PAnsiChar): cbool; cdecl;
+function SDL_SetAppMetadataProperty(name: PAnsiChar; value: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetAppMetadataProperty' {$ENDIF} {$ENDIF};
 
 const

--- a/units/SDL_iostream.inc
+++ b/units/SDL_iostream.inc
@@ -120,7 +120,7 @@ type
        *
        *  \return true if successful or false on write error when flushing data.
         }
-      flush: function (userdata: Pointer; status: PSDL_IOStatus): cbool; cdecl;
+      flush: function (userdata: Pointer; status: PSDL_IOStatus): Boolean; cdecl;
 
       {*
        *  Close and free any allocated resources.
@@ -133,7 +133,7 @@ type
        *
        *  \return true if successful or false on write error when flushing data.
         }
-      close: function (userdata: Pointer): cbool; cdecl;
+      close: function (userdata: Pointer): Boolean; cdecl;
     end;
 
 { Check the size of SDL_IOStreamInterface
@@ -442,7 +442,7 @@ function SDL_OpenIO(iface: PSDL_IOStreamInterface; userdata: Pointer): PSDL_IOSt
  *
  * \sa SDL_OpenIO
   }
-function SDL_CloseIO(context: PSDL_IOStream): cbool; cdecl;
+function SDL_CloseIO(context: PSDL_IOStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CloseIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -668,7 +668,7 @@ function SDL_IOprintf(context: PSDL_IOStream; fmt: PAnsiChar): csize_t; cdecl; o
  * \sa SDL_OpenIO
  * \sa SDL_WriteIO
   }
-function SDL_FlushIO(context: PSDL_IOStream): cbool; cdecl;
+function SDL_FlushIO(context: PSDL_IOStream): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FlushIO' {$ENDIF} {$ENDIF};
 
 {*
@@ -695,7 +695,7 @@ function SDL_FlushIO(context: PSDL_IOStream): cbool; cdecl;
  * \sa SDL_LoadFile
  * \sa SDL_SaveFile_IO
   }
-function SDL_LoadFile_IO(src: PSDL_IOStream; datasize: pcsize_t; closeio: cbool): Pointer; cdecl;
+function SDL_LoadFile_IO(src: PSDL_IOStream; datasize: pcsize_t; closeio: Boolean): Pointer; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LoadFile_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -741,7 +741,7 @@ function SDL_LoadFile(file_: PAnsiChar; datasize: pcsize_t): Pointer; cdecl;
  * \sa SDL_SaveFile
  * \sa SDL_LoadFile_IO
   }
-function SDL_SaveFile_IO(src: PSDL_IOStream; data: Pointer; datasize: csize_t; closeio: cbool): cbool; cdecl;
+function SDL_SaveFile_IO(src: PSDL_IOStream; data: Pointer; datasize: csize_t; closeio: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SaveFile_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -761,7 +761,7 @@ function SDL_SaveFile_IO(src: PSDL_IOStream; data: Pointer; datasize: csize_t; c
  * \sa SDL_SaveFile_IO
  * \sa SDL_LoadFile
   }
-function SDL_SaveFile(file_: PAnsiChar; data: Pointer; datasize: csize_t): cbool; cdecl;
+function SDL_SaveFile(file_: PAnsiChar; data: Pointer; datasize: csize_t): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SaveFile' {$ENDIF} {$ENDIF};
 
 {*
@@ -787,7 +787,7 @@ function SDL_SaveFile(file_: PAnsiChar; data: Pointer; datasize: csize_t): cbool
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU8(src: PSDL_IOStream; value: pcuint8): cbool; cdecl;
+function SDL_ReadU8(src: PSDL_IOStream; value: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU8' {$ENDIF} {$ENDIF};
 
 {*
@@ -807,7 +807,7 @@ function SDL_ReadU8(src: PSDL_IOStream; value: pcuint8): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS8(src: PSDL_IOStream; value: pcint8): cbool; cdecl;
+function SDL_ReadS8(src: PSDL_IOStream; value: pcint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS8' {$ENDIF} {$ENDIF};
 
 {*
@@ -831,7 +831,7 @@ function SDL_ReadS8(src: PSDL_IOStream; value: pcint8): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU16LE(src: PSDL_IOStream; value: pcuint16): cbool; cdecl;
+function SDL_ReadU16LE(src: PSDL_IOStream; value: pcuint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU16LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -855,7 +855,7 @@ function SDL_ReadU16LE(src: PSDL_IOStream; value: pcuint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS16LE(src: PSDL_IOStream; value: pcint16): cbool; cdecl;
+function SDL_ReadS16LE(src: PSDL_IOStream; value: pcint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS16LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -879,7 +879,7 @@ function SDL_ReadS16LE(src: PSDL_IOStream; value: pcint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU16BE(src: PSDL_IOStream; value: pcuint16): cbool; cdecl;
+function SDL_ReadU16BE(src: PSDL_IOStream; value: pcuint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU16BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -903,7 +903,7 @@ function SDL_ReadU16BE(src: PSDL_IOStream; value: pcuint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS16BE(src: PSDL_IOStream; value: pcint16): cbool; cdecl;
+function SDL_ReadS16BE(src: PSDL_IOStream; value: pcint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS16BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -927,7 +927,7 @@ function SDL_ReadS16BE(src: PSDL_IOStream; value: pcint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU32LE(src: PSDL_IOStream; value: pcuint32): cbool; cdecl;
+function SDL_ReadU32LE(src: PSDL_IOStream; value: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU32LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -951,7 +951,7 @@ function SDL_ReadU32LE(src: PSDL_IOStream; value: pcuint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS32LE(src: PSDL_IOStream; value: pcint32): cbool; cdecl;
+function SDL_ReadS32LE(src: PSDL_IOStream; value: pcint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS32LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -975,7 +975,7 @@ function SDL_ReadS32LE(src: PSDL_IOStream; value: pcint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU32BE(src: PSDL_IOStream; value: pcuint32): cbool; cdecl;
+function SDL_ReadU32BE(src: PSDL_IOStream; value: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU32BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -999,7 +999,7 @@ function SDL_ReadU32BE(src: PSDL_IOStream; value: pcuint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS32BE(src: PSDL_IOStream; value: pcint32): cbool; cdecl;
+function SDL_ReadS32BE(src: PSDL_IOStream; value: pcint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS32BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1023,7 +1023,7 @@ function SDL_ReadS32BE(src: PSDL_IOStream; value: pcint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU64LE(src: PSDL_IOStream; value: pcuint64): cbool; cdecl;
+function SDL_ReadU64LE(src: PSDL_IOStream; value: pcuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU64LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1047,7 +1047,7 @@ function SDL_ReadU64LE(src: PSDL_IOStream; value: pcuint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS64LE(src: PSDL_IOStream; value: pcint64): cbool; cdecl;
+function SDL_ReadS64LE(src: PSDL_IOStream; value: pcint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS64LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1071,7 +1071,7 @@ function SDL_ReadS64LE(src: PSDL_IOStream; value: pcint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadU64BE(src: PSDL_IOStream; value: pcuint64): cbool; cdecl;
+function SDL_ReadU64BE(src: PSDL_IOStream; value: pcuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadU64BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1095,7 +1095,7 @@ function SDL_ReadU64BE(src: PSDL_IOStream; value: pcuint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_ReadS64BE(src: PSDL_IOStream; value: pcint64): cbool; cdecl;
+function SDL_ReadS64BE(src: PSDL_IOStream; value: pcint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadS64BE' {$ENDIF} {$ENDIF};
 
 { Read endian functions  }
@@ -1118,7 +1118,7 @@ function SDL_ReadS64BE(src: PSDL_IOStream; value: pcint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU8(dst: PSDL_IOStream; value: cuint8): cbool; cdecl;
+function SDL_WriteU8(dst: PSDL_IOStream; value: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU8' {$ENDIF} {$ENDIF};
 
 {*
@@ -1133,7 +1133,7 @@ function SDL_WriteU8(dst: PSDL_IOStream; value: cuint8): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS8(dst: PSDL_IOStream; value: cint8): cbool; cdecl;
+function SDL_WriteS8(dst: PSDL_IOStream; value: cint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS8' {$ENDIF} {$ENDIF};
 
 {*
@@ -1153,7 +1153,7 @@ function SDL_WriteS8(dst: PSDL_IOStream; value: cint8): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU16LE(dst: PSDL_IOStream; value: cuint16): cbool; cdecl;
+function SDL_WriteU16LE(dst: PSDL_IOStream; value: cuint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU16LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1173,7 +1173,7 @@ function SDL_WriteU16LE(dst: PSDL_IOStream; value: cuint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS16LE(dst: PSDL_IOStream; value: cint16): cbool; cdecl;
+function SDL_WriteS16LE(dst: PSDL_IOStream; value: cint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS16LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1192,7 +1192,7 @@ function SDL_WriteS16LE(dst: PSDL_IOStream; value: cint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU16BE(dst: PSDL_IOStream; value: cuint16): cbool; cdecl;
+function SDL_WriteU16BE(dst: PSDL_IOStream; value: cuint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU16BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1211,7 +1211,7 @@ function SDL_WriteU16BE(dst: PSDL_IOStream; value: cuint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS16BE(dst: PSDL_IOStream; value: cint16): cbool; cdecl;
+function SDL_WriteS16BE(dst: PSDL_IOStream; value: cint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS16BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1231,7 +1231,7 @@ function SDL_WriteS16BE(dst: PSDL_IOStream; value: cint16): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU32LE(dst: PSDL_IOStream; value: cuint32): cbool; cdecl;
+function SDL_WriteU32LE(dst: PSDL_IOStream; value: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU32LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1251,7 +1251,7 @@ function SDL_WriteU32LE(dst: PSDL_IOStream; value: cuint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS32LE(dst: PSDL_IOStream; value: cint32): cbool; cdecl;
+function SDL_WriteS32LE(dst: PSDL_IOStream; value: cint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS32LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1270,7 +1270,7 @@ function SDL_WriteS32LE(dst: PSDL_IOStream; value: cint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU32BE(dst: PSDL_IOStream; value: cuint32): cbool; cdecl;
+function SDL_WriteU32BE(dst: PSDL_IOStream; value: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU32BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1289,7 +1289,7 @@ function SDL_WriteU32BE(dst: PSDL_IOStream; value: cuint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS32BE(dst: PSDL_IOStream; value: cint32): cbool; cdecl;
+function SDL_WriteS32BE(dst: PSDL_IOStream; value: cint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS32BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1309,7 +1309,7 @@ function SDL_WriteS32BE(dst: PSDL_IOStream; value: cint32): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU64LE(dst: PSDL_IOStream; value: cuint64): cbool; cdecl;
+function SDL_WriteU64LE(dst: PSDL_IOStream; value: cuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU64LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1329,7 +1329,7 @@ function SDL_WriteU64LE(dst: PSDL_IOStream; value: cuint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS64LE(dst: PSDL_IOStream; value: cint64): cbool; cdecl;
+function SDL_WriteS64LE(dst: PSDL_IOStream; value: cint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS64LE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1348,7 +1348,7 @@ function SDL_WriteS64LE(dst: PSDL_IOStream; value: cint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteU64BE(dst: PSDL_IOStream; value: cuint64): cbool; cdecl;
+function SDL_WriteU64BE(dst: PSDL_IOStream; value: cuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteU64BE' {$ENDIF} {$ENDIF};
 
 {*
@@ -1367,6 +1367,6 @@ function SDL_WriteU64BE(dst: PSDL_IOStream; value: cuint64): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_WriteS64BE(dst: PSDL_IOStream; value: cint64): cbool; cdecl;
+function SDL_WriteS64BE(dst: PSDL_IOStream; value: cint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteS64BE' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_joystick.inc
+++ b/units/SDL_joystick.inc
@@ -161,7 +161,7 @@ const
  *
  * \sa SDL_GetJoysticks
   }
-function SDL_HasJoystick: cbool; cdecl;
+function SDL_HasJoystick: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasJoystick' {$ENDIF} {$ENDIF};
 
 {*
@@ -433,11 +433,11 @@ type
       userdata: Pointer;                                                        {*< User data Pointer passed to callbacks  }
       Update: procedure (userdata: Pointer); cdecl;                             {*< Called when the joystick state should be updated  }
       SetPlayerIndex: procedure (userdata: Pointer; player_index: cint); cdecl; {*< Called when the player index is set  }
-      Rumble: function (userdata: Pointer; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16): cbool; cdecl; {*< Implements SDL_RumbleJoystick()  }
-      RumbleTriggers: function (userdata: Pointer; left_rumble: cuint16; right_rumble: cuint16): cbool; cdecl;           {*< Implements SDL_RumbleJoystickTriggers()  }
-      SetLED: function (userdata: Pointer; red: cuint8; green: cuint8; blue: cuint8): cbool; cdecl;                      {*< Implements SDL_SetJoystickLED()  }
-      SendEffect: function (userdata: Pointer; data: Pointer; size: cint): cbool; cdecl; {*< Implements SDL_SendJoystickEffect()  }
-      SetSensorsEnabled: function (userdata: Pointer; enabled: cbool): cbool; cdecl;     {*< Implements SDL_SetGamepadSensorEnabled()  }
+      Rumble: function (userdata: Pointer; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16): Boolean; cdecl; {*< Implements SDL_RumbleJoystick()  }
+      RumbleTriggers: function (userdata: Pointer; left_rumble: cuint16; right_rumble: cuint16): Boolean; cdecl;           {*< Implements SDL_RumbleJoystickTriggers()  }
+      SetLED: function (userdata: Pointer; red: cuint8; green: cuint8; blue: cuint8): Boolean; cdecl;                      {*< Implements SDL_SetJoystickLED()  }
+      SendEffect: function (userdata: Pointer; data: Pointer; size: cint): Boolean; cdecl;                                 {*< Implements SDL_SendJoystickEffect()  }
+      SetSensorsEnabled: function (userdata: Pointer; enabled: Boolean): Boolean; cdecl;                                   {*< Implements SDL_SetGamepadSensorEnabled()  }
       Cleanup: procedure (userdata: Pointer); cdecl;                                     {*< Cleans up the userdata when the joystick is detached  }
     end;
 
@@ -476,7 +476,7 @@ function SDL_AttachVirtualJoystick(desc: PSDL_VirtualJoystickDesc): TSDL_Joystic
  *
  * \sa SDL_AttachVirtualJoystick
   }
-function SDL_DetachVirtualJoystick(instance_id: TSDL_JoystickID): cbool; cdecl;
+function SDL_DetachVirtualJoystick(instance_id: TSDL_JoystickID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_DetachVirtualJoystick' {$ENDIF} {$ENDIF};
 
 {*
@@ -487,7 +487,7 @@ function SDL_DetachVirtualJoystick(instance_id: TSDL_JoystickID): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_IsJoystickVirtual(instance_id: TSDL_JoystickID): cbool; cdecl;
+function SDL_IsJoystickVirtual(instance_id: TSDL_JoystickID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_IsJoystickVirtual' {$ENDIF} {$ENDIF};
 
 {*
@@ -511,7 +511,7 @@ function SDL_IsJoystickVirtual(instance_id: TSDL_JoystickID): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickVirtualAxis(joystick: PSDL_Joystick; axis: cint; value: cint16): cbool; cdecl;
+function SDL_SetJoystickVirtualAxis(joystick: PSDL_Joystick; axis: cint; value: cint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickVirtualAxis' {$ENDIF} {$ENDIF};
 
 {*
@@ -532,7 +532,7 @@ function SDL_SetJoystickVirtualAxis(joystick: PSDL_Joystick; axis: cint; value: 
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickVirtualBall(joystick: PSDL_Joystick; ball: cint; xrel: cint16; yrel: cint16): cbool; cdecl;
+function SDL_SetJoystickVirtualBall(joystick: PSDL_Joystick; ball: cint; xrel: cint16; yrel: cint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickVirtualBall' {$ENDIF} {$ENDIF};
 
 {*
@@ -552,7 +552,7 @@ function SDL_SetJoystickVirtualBall(joystick: PSDL_Joystick; ball: cint; xrel: c
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickVirtualButton(joystick: PSDL_Joystick; button: cint; down: cbool): cbool; cdecl;
+function SDL_SetJoystickVirtualButton(joystick: PSDL_Joystick; button: cint; down: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickVirtualButton' {$ENDIF} {$ENDIF};
 
 {*
@@ -572,7 +572,7 @@ function SDL_SetJoystickVirtualButton(joystick: PSDL_Joystick; button: cint; dow
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickVirtualHat(joystick: PSDL_Joystick; hat: cint; value: cuint8): cbool; cdecl;
+function SDL_SetJoystickVirtualHat(joystick: PSDL_Joystick; hat: cint; value: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickVirtualHat' {$ENDIF} {$ENDIF};
 
 {*
@@ -599,8 +599,8 @@ function SDL_SetJoystickVirtualHat(joystick: PSDL_Joystick; hat: cint; value: cu
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickVirtualTouchpad(joystick: PSDL_Joystick; touchpad: cint; finger: cint; down: cbool; x: cfloat;
-           y: cfloat; pressure: cfloat): cbool; cdecl;
+function SDL_SetJoystickVirtualTouchpad(joystick: PSDL_Joystick; touchpad: cint; finger: cint; down: Boolean; x: cfloat;
+           y: cfloat; pressure: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickVirtualTouchpad' {$ENDIF} {$ENDIF};
 
 {*
@@ -623,7 +623,7 @@ function SDL_SetJoystickVirtualTouchpad(joystick: PSDL_Joystick; touchpad: cint;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SendJoystickVirtualSensorData(joystick: PSDL_Joystick; type_: TSDL_SensorType; sensor_timestamp: cuint64; data: pcfloat; num_values: cint): cbool; cdecl;
+function SDL_SendJoystickVirtualSensorData(joystick: PSDL_Joystick; type_: TSDL_SensorType; sensor_timestamp: cuint64; data: pcfloat; num_values: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SendJoystickVirtualSensorData' {$ENDIF} {$ENDIF};
 
 {*
@@ -715,7 +715,7 @@ function SDL_GetJoystickPlayerIndex(joystick: PSDL_Joystick): cint; cdecl;
  *
  * \sa SDL_GetJoystickPlayerIndex
   }
-function SDL_SetJoystickPlayerIndex(joystick: PSDL_Joystick; player_index: cint): cbool; cdecl;
+function SDL_SetJoystickPlayerIndex(joystick: PSDL_Joystick; player_index: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickPlayerIndex' {$ENDIF} {$ENDIF};
 
 {*
@@ -851,7 +851,7 @@ procedure SDL_GetJoystickGUIDInfo(guid: TSDL_GUID; vendor: pcuint16; product: pc
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_JoystickConnected(joystick: PSDL_Joystick): cbool; cdecl;
+function SDL_JoystickConnected(joystick: PSDL_Joystick): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickConnected' {$ENDIF} {$ENDIF};
 
 {*
@@ -957,7 +957,7 @@ function SDL_GetNumJoystickButtons(joystick: PSDL_Joystick): cint; cdecl;
  * \sa SDL_JoystickEventsEnabled
  * \sa SDL_UpdateJoysticks
   }
-procedure SDL_SetJoystickEventsEnabled(enabled: cbool); cdecl;
+procedure SDL_SetJoystickEventsEnabled(enabled: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickEventsEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -973,7 +973,7 @@ procedure SDL_SetJoystickEventsEnabled(enabled: cbool); cdecl;
  *
  * \sa SDL_SetJoystickEventsEnabled
   }
-function SDL_JoystickEventsEnabled: cbool; cdecl;
+function SDL_JoystickEventsEnabled: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickEventsEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1026,7 +1026,7 @@ function SDL_GetJoystickAxis(joystick: PSDL_Joystick; axis: cint): cint16; cdecl
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetJoystickAxisInitialState(joystick: PSDL_Joystick; axis: cint; state: pcint16): cbool; cdecl;
+function SDL_GetJoystickAxisInitialState(joystick: PSDL_Joystick; axis: cint; state: pcint16): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetJoystickAxisInitialState' {$ENDIF} {$ENDIF};
 
 {*
@@ -1048,7 +1048,7 @@ function SDL_GetJoystickAxisInitialState(joystick: PSDL_Joystick; axis: cint; st
  *
  * \sa SDL_GetNumJoystickBalls
   }
-function SDL_GetJoystickBall(joystick: PSDL_Joystick; ball: cint; dx: pcint; dy: pcint): cbool; cdecl;
+function SDL_GetJoystickBall(joystick: PSDL_Joystick; ball: cint; dx: pcint; dy: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetJoystickBall' {$ENDIF} {$ENDIF};
 
 {*
@@ -1090,7 +1090,7 @@ const
  *
  * \sa SDL_GetNumJoystickButtons
   }
-function SDL_GetJoystickButton(joystick: PSDL_Joystick; button: cint): cbool; cdecl;
+function SDL_GetJoystickButton(joystick: PSDL_Joystick; button: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetJoystickButton' {$ENDIF} {$ENDIF};
 
 {*
@@ -1112,7 +1112,7 @@ function SDL_GetJoystickButton(joystick: PSDL_Joystick; button: cint): cbool; cd
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_RumbleJoystick(joystick: PSDL_Joystick; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16; duration_ms: cuint32): cbool; cdecl;
+function SDL_RumbleJoystick(joystick: PSDL_Joystick; low_frequency_rumble: cuint16; high_frequency_rumble: cuint16; duration_ms: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RumbleJoystick' {$ENDIF} {$ENDIF};
 
 {*
@@ -1142,7 +1142,7 @@ function SDL_RumbleJoystick(joystick: PSDL_Joystick; low_frequency_rumble: cuint
  *
  * \sa SDL_RumbleJoystick
   }
-function SDL_RumbleJoystickTriggers(joystick: PSDL_Joystick; left_rumble: cuint16; right_rumble: cuint16; duration_ms: cuint32): cbool; cdecl;
+function SDL_RumbleJoystickTriggers(joystick: PSDL_Joystick; left_rumble: cuint16; right_rumble: cuint16; duration_ms: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RumbleJoystickTriggers' {$ENDIF} {$ENDIF};
 
 {*
@@ -1163,7 +1163,7 @@ function SDL_RumbleJoystickTriggers(joystick: PSDL_Joystick; left_rumble: cuint1
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetJoystickLED(joystick: PSDL_Joystick; red: cuint8; green: cuint8; blue: cuint8): cbool; cdecl;
+function SDL_SetJoystickLED(joystick: PSDL_Joystick; red: cuint8; green: cuint8; blue: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetJoystickLED' {$ENDIF} {$ENDIF};
 
 {*
@@ -1177,7 +1177,7 @@ function SDL_SetJoystickLED(joystick: PSDL_Joystick; red: cuint8; green: cuint8;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SendJoystickEffect(joystick: PSDL_Joystick; data: Pointer; size: cint): cbool; cdecl;
+function SDL_SendJoystickEffect(joystick: PSDL_Joystick; data: Pointer; size: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SendJoystickEffect' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_keyboard.inc
+++ b/units/SDL_keyboard.inc
@@ -38,7 +38,7 @@ type
  *
  * \sa SDL_GetKeyboards
   }
-function SDL_HasKeyboard: cbool; cdecl;
+function SDL_HasKeyboard: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasKeyboard' {$ENDIF} {$ENDIF};
 
 {*
@@ -118,7 +118,7 @@ function SDL_GetKeyboardFocus: PSDL_Window; cdecl;
  * \sa SDL_PumpEvents
  * \sa SDL_ResetKeyboard
   }
-function SDL_GetKeyboardState(numkeys: pcint): pcbool; cdecl;
+function SDL_GetKeyboardState(numkeys: pcint): pBoolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetKeyboardState' {$ENDIF} {$ENDIF};
 
 {*
@@ -187,7 +187,7 @@ procedure SDL_SetModState(modstate: TSDL_Keymod); cdecl;
  * \sa SDL_GetKeyName
  * \sa SDL_GetScancodeFromKey
   }
-function SDL_GetKeyFromScancode(scancode: TSDL_Scancode; modstate: TSDL_Keymod; key_event: cbool): TSDL_Keycode; cdecl;
+function SDL_GetKeyFromScancode(scancode: TSDL_Scancode; modstate: TSDL_Keymod; key_event: Boolean): TSDL_Keycode; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetKeyFromScancode' {$ENDIF} {$ENDIF};
 
 {*
@@ -224,7 +224,7 @@ function SDL_GetScancodeFromKey(key: TSDL_Keycode; modstate: PSDL_Keymod): TSDL_
  *
  * \sa SDL_GetScancodeName
   }
-function SDL_SetScancodeName(scancode: TSDL_Scancode; name: PAnsiChar): cbool; cdecl;
+function SDL_SetScancodeName(scancode: TSDL_Scancode; name: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetScancodeName' {$ENDIF} {$ENDIF};
 
 {*
@@ -325,7 +325,7 @@ function SDL_GetKeyFromName(name: PAnsiChar): TSDL_Keycode; cdecl;
  * \sa SDL_StopTextInput
  * \sa SDL_TextInputActive
   }
-function SDL_StartTextInput(window: PSDL_Window): cbool; cdecl;
+function SDL_StartTextInput(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StartTextInput' {$ENDIF} {$ENDIF};
 
 {*
@@ -424,7 +424,7 @@ const
  * \sa SDL_StopTextInput
  * \sa SDL_TextInputActive
   }
-function SDL_StartTextInputWithProperties(window: PSDL_Window; props: TSDL_PropertiesID): cbool; cdecl;
+function SDL_StartTextInputWithProperties(window: PSDL_Window; props: TSDL_PropertiesID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StartTextInputWithProperties' {$ENDIF} {$ENDIF};
 
   const
@@ -444,7 +444,7 @@ function SDL_StartTextInputWithProperties(window: PSDL_Window; props: TSDL_Prope
  *
  * \sa SDL_StartTextInput
   }
-function SDL_TextInputActive(window: PSDL_Window): cbool; cdecl;
+function SDL_TextInputActive(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_TextInputActive' {$ENDIF} {$ENDIF};
 
 {*
@@ -461,7 +461,7 @@ function SDL_TextInputActive(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_StartTextInput
   }
-function SDL_StopTextInput(window: PSDL_Window): cbool; cdecl;
+function SDL_StopTextInput(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StopTextInput' {$ENDIF} {$ENDIF};
 
 {*
@@ -476,7 +476,7 @@ function SDL_StopTextInput(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_StartTextInput
  * \sa SDL_StopTextInput
   }
-function SDL_ClearComposition(window: PSDL_Window): cbool; cdecl;
+function SDL_ClearComposition(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearComposition' {$ENDIF} {$ENDIF};
 
 {*
@@ -499,7 +499,7 @@ function SDL_ClearComposition(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_StartTextInput
   }
 
-function SDL_SetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: cint): cbool; cdecl;
+function SDL_SetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextInputArea' {$ENDIF} {$ENDIF};
 
 {*
@@ -519,7 +519,7 @@ function SDL_SetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: cint
  *
  * \sa SDL_SetTextInputArea
   }
-function SDL_GetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: pcint): cbool; cdecl;
+function SDL_GetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextInputArea' {$ENDIF} {$ENDIF};
 
 {*
@@ -533,7 +533,7 @@ function SDL_GetTextInputArea(window: PSDL_Window; rect: PSDL_Rect; cursor: pcin
  * \sa SDL_StartTextInput
  * \sa SDL_ScreenKeyboardShown
   }
-function SDL_HasScreenKeyboardSupport: cbool; cdecl;
+function SDL_HasScreenKeyboardSupport: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasScreenKeyboardSupport' {$ENDIF} {$ENDIF};
 
 {*
@@ -546,6 +546,6 @@ function SDL_HasScreenKeyboardSupport: cbool; cdecl;
  *
  * \sa SDL_HasScreenKeyboardSupport
   }
-function SDL_ScreenKeyboardShown(window: PSDL_Window): cbool; cdecl;
+function SDL_ScreenKeyboardShown(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ScreenKeyboardShown' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_log.inc
+++ b/units/SDL_log.inc
@@ -193,7 +193,7 @@ procedure SDL_ResetLogPriorities; cdecl;
  * \sa SDL_SetLogPriorities
  * \sa SDL_SetLogPriority
   }
-function SDL_SetLogPriorityPrefix(priority: TSDL_LogPriority; prefix: PAnsiChar): cbool; cdecl;
+function SDL_SetLogPriorityPrefix(priority: TSDL_LogPriority; prefix: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetLogPriorityPrefix' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_messagebox.inc
+++ b/units/SDL_messagebox.inc
@@ -164,7 +164,7 @@ type
  *
  * \sa SDL_ShowSimpleMessageBox
   }
-function SDL_ShowMessageBox(messageboxdata: PSDL_MessageBoxData; buttonid: pcint): cbool; cdecl;
+function SDL_ShowMessageBox(messageboxdata: PSDL_MessageBoxData; buttonid: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowMessageBox' {$ENDIF} {$ENDIF};
 
 {*
@@ -207,6 +207,6 @@ function SDL_ShowMessageBox(messageboxdata: PSDL_MessageBoxData; buttonid: pcint
  *
  * \sa SDL_ShowMessageBox
   }
-function SDL_ShowSimpleMessageBox(flags: TSDL_MessageBoxFlags; title: PAnsiChar; message: PAnsiChar; window: PSDL_Window): cbool; cdecl;
+function SDL_ShowSimpleMessageBox(flags: TSDL_MessageBoxFlags; title: PAnsiChar; message: PAnsiChar; window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowSimpleMessageBox' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_misc.inc
+++ b/units/SDL_misc.inc
@@ -42,6 +42,6 @@
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_OpenURL(url: PAnsiChar): cbool; cdecl;
+function SDL_OpenURL(url: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_OpenURL' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_mouse.inc
+++ b/units/SDL_mouse.inc
@@ -130,7 +130,7 @@ const
  *
  * \sa SDL_GetMice
   }
-function SDL_HasMouse: cbool; cdecl;
+function SDL_HasMouse: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasMouse' {$ENDIF} {$ENDIF};
 
 {*
@@ -297,7 +297,7 @@ procedure SDL_WarpMouseInWindow(window: PSDL_Window; x: cfloat; y: cfloat); cdec
  *
  * \sa SDL_WarpMouseInWindow
   }
-function SDL_WarpMouseGlobal(x: cfloat; y: cfloat): cbool; cdecl;
+function SDL_WarpMouseGlobal(x: cfloat; y: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WarpMouseGlobal' {$ENDIF} {$ENDIF};
 
 {*
@@ -319,7 +319,7 @@ function SDL_WarpMouseGlobal(x: cfloat; y: cfloat): cbool; cdecl;
  *
  * \sa SDL_GetWindowRelativeMouseMode
   }
-function SDL_SetWindowRelativeMouseMode(window: PSDL_Window; enabled: cbool): cbool; cdecl;
+function SDL_SetWindowRelativeMouseMode(window: PSDL_Window; enabled: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowRelativeMouseMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -332,7 +332,7 @@ function SDL_SetWindowRelativeMouseMode(window: PSDL_Window; enabled: cbool): cb
  *
  * \sa SDL_SetWindowRelativeMouseMode
   }
-function SDL_GetWindowRelativeMouseMode(window: PSDL_Window): cbool; cdecl;
+function SDL_GetWindowRelativeMouseMode(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowRelativeMouseMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -379,7 +379,7 @@ function SDL_GetWindowRelativeMouseMode(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_GetGlobalMouseState
   }
-function SDL_CaptureMouse(enabled: cbool): cbool; cdecl;
+function SDL_CaptureMouse(enabled: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CaptureMouse' {$ENDIF} {$ENDIF};
 
 {*
@@ -486,7 +486,7 @@ function SDL_CreateSystemCursor(id: TSDL_SystemCursor): PSDL_Cursor; cdecl;
  *
  * \sa SDL_GetCursor
   }
-function SDL_SetCursor(cursor: PSDL_Cursor): cbool; cdecl;
+function SDL_SetCursor(cursor: PSDL_Cursor): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetCursor' {$ENDIF} {$ENDIF};
 
 {*
@@ -546,7 +546,7 @@ procedure SDL_DestroyCursor(cursor: PSDL_Cursor); cdecl;
  * \sa SDL_CursorVisible
  * \sa SDL_HideCursor
   }
-function SDL_ShowCursor: cbool; cdecl;
+function SDL_ShowCursor: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowCursor' {$ENDIF} {$ENDIF};
 
 {*
@@ -560,7 +560,7 @@ function SDL_ShowCursor: cbool; cdecl;
  * \sa SDL_CursorVisible
  * \sa SDL_ShowCursor
   }
-function SDL_HideCursor: cbool; cdecl;
+function SDL_HideCursor: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HideCursor' {$ENDIF} {$ENDIF};
 
 {*
@@ -574,5 +574,5 @@ function SDL_HideCursor: cbool; cdecl;
  * \sa SDL_HideCursor
  * \sa SDL_ShowCursor
   }
-function SDL_CursorVisible: cbool; cdecl;
+function SDL_CursorVisible: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CursorVisible' {$ENDIF} {$ENDIF};

--- a/units/SDL_pixels.inc
+++ b/units/SDL_pixels.inc
@@ -740,7 +740,7 @@ function SDL_GetPixelFormatName(format: TSDL_PixelFormat): PAnsiChar; cdecl;
  *
  * \sa SDL_GetPixelFormatForMasks
   }
-function SDL_GetMasksForPixelFormat(format: TSDL_PixelFormat; bpp: pcint; Rmask: pcuint32; Gmask: pcuint32; Bmask: pcuint32; Amask: pcuint32): cbool; cdecl;
+function SDL_GetMasksForPixelFormat(format: TSDL_PixelFormat; bpp: pcint; Rmask: pcuint32; Gmask: pcuint32; Bmask: pcuint32; Amask: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetMasksForPixelFormat' {$ENDIF} {$ENDIF};
 
 {*
@@ -819,7 +819,7 @@ function SDL_CreatePalette(ncolors: cint): PSDL_Palette; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetPaletteColors(palette: PSDL_Palette; colors: PSDL_Color; firstcolor: cint; ncolors: cint): cbool; cdecl;
+function SDL_SetPaletteColors(palette: PSDL_Palette; colors: PSDL_Color; firstcolor: cint; ncolors: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetPaletteColors' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_process.inc
+++ b/units/SDL_process.inc
@@ -78,7 +78,7 @@ type
  * \sa SDL_WaitProcess
  * \sa SDL_DestroyProcess
   }
-function SDL_CreateProcess(args: PPAnsiChar; pipe_stdio: cbool): PSDL_Process; cdecl;
+function SDL_CreateProcess(args: PPAnsiChar; pipe_stdio: Boolean): PSDL_Process; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CreateProcess' {$ENDIF} {$ENDIF};
 
 {*
@@ -352,7 +352,7 @@ function SDL_GetProcessOutput(process: PSDL_Process): PSDL_IOStream; cdecl;
  * \sa SDL_WaitProcess
  * \sa SDL_DestroyProcess
   }
-function SDL_KillProcess(process: PSDL_Process; force: cbool): cbool; cdecl;
+function SDL_KillProcess(process: PSDL_Process; force: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_KillProcess' {$ENDIF} {$ENDIF};
 
 {*
@@ -386,7 +386,7 @@ function SDL_KillProcess(process: PSDL_Process; force: cbool): cbool; cdecl;
  * \sa SDL_KillProcess
  * \sa SDL_DestroyProcess
   }
-function SDL_WaitProcess(process: PSDL_Process; block: cbool; exitcode: pcint): cbool; cdecl;
+function SDL_WaitProcess(process: PSDL_Process; block: Boolean; exitcode: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WaitProcess' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_properties.inc
+++ b/units/SDL_properties.inc
@@ -26,7 +26,7 @@
  *   integer types.
  * - SDL_SetFloatProperty and SDL_GetFloatProperty operate on floating point
  *   types.
- * - SDL_SecbooleanProperty and SDL_GecbooleanProperty operate on boolean
+ * - SDL_SetBooleanProperty and SDL_GetBooleanProperty operate on boolean
  *   types.
  *
  * Properties can be removed from a group by using SDL_ClearProperty.
@@ -104,7 +104,7 @@ function SDL_CreateProperties: TSDL_PropertiesID; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_CopyProperties(src: TSDL_PropertiesID; dst: TSDL_PropertiesID): cbool; cdecl;
+function SDL_CopyProperties(src: TSDL_PropertiesID; dst: TSDL_PropertiesID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CopyProperties' {$ENDIF} {$ENDIF};
 
 {*
@@ -129,7 +129,7 @@ function SDL_CopyProperties(src: TSDL_PropertiesID; dst: TSDL_PropertiesID): cbo
  *
  * \sa SDL_UnlockProperties
   }
-function SDL_LockProperties(props: TSDL_PropertiesID): cbool; cdecl;
+function SDL_LockProperties(props: TSDL_PropertiesID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LockProperties' {$ENDIF} {$ENDIF};
 
 {*
@@ -179,7 +179,7 @@ type
  * reason.
  *
  * For simply setting basic data types, like numbers, bools, or strings, use
- * SDL_SetNumberProperty, SDL_SecbooleanProperty, or SDL_SetStringProperty
+ * SDL_SetNumberProperty, SDL_SetBooleanProperty, or SDL_SetStringProperty
  * instead, as those functions will handle cleanup on your behalf. This
  * function is only for more complex, custom data.
  *
@@ -200,7 +200,7 @@ type
  * \sa SDL_SetPointerProperty
  * \sa SDL_CleanupPropertyCallback
   }
-function SDL_SetPointerPropertyWithCleanup(props: TSDL_PropertiesID; name: PAnsiChar; value: Pointer; cleanup: TSDL_CleanupPropertyCallback; userdata: Pointer): cbool; cdecl;
+function SDL_SetPointerPropertyWithCleanup(props: TSDL_PropertiesID; name: PAnsiChar; value: Pointer; cleanup: TSDL_CleanupPropertyCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetPointerPropertyWithCleanup' {$ENDIF} {$ENDIF};
 
 {*
@@ -218,13 +218,13 @@ function SDL_SetPointerPropertyWithCleanup(props: TSDL_PropertiesID; name: PAnsi
  *
  * \sa SDL_GetPointerProperty
  * \sa SDL_HasProperty
- * \sa SDL_SecbooleanProperty
+ * \sa SDL_SetBooleanProperty
  * \sa SDL_SetFloatProperty
  * \sa SDL_SetNumberProperty
  * \sa SDL_SetPointerPropertyWithCleanup
  * \sa SDL_SetStringProperty
   }
-function SDL_SetPointerProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: Pointer): cbool; cdecl;
+function SDL_SetPointerProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetPointerProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -245,7 +245,7 @@ function SDL_SetPointerProperty(props: TSDL_PropertiesID; name: PAnsiChar; value
  *
  * \sa SDL_GetStringProperty
   }
-function SDL_SetStringProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: PAnsiChar): cbool; cdecl;
+function SDL_SetStringProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetStringProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -263,7 +263,7 @@ function SDL_SetStringProperty(props: TSDL_PropertiesID; name: PAnsiChar; value:
  *
  * \sa SDL_GetNumberProperty
   }
-function SDL_SetNumberProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: cint64): cbool; cdecl;
+function SDL_SetNumberProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: cint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetNumberProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -281,7 +281,7 @@ function SDL_SetNumberProperty(props: TSDL_PropertiesID; name: PAnsiChar; value:
  *
  * \sa SDL_GetFloatProperty
   }
-function SDL_SetFloatProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: cfloat): cbool; cdecl;
+function SDL_SetFloatProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetFloatProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -297,10 +297,10 @@ function SDL_SetFloatProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: 
  *
  * \since This function is available since SDL 3.1.3.
  *
- * \sa SDL_GecbooleanProperty
+ * \sa SDL_GetBooleanProperty
   }
-function SDL_SecbooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: cbool): cbool; cdecl;
-  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SecbooleanProperty' {$ENDIF} {$ENDIF};
+function SDL_SetBooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; value: Boolean): Boolean; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetBooleanProperty' {$ENDIF} {$ENDIF};
 
 {*
  * Return whether a property exists in a group of properties.
@@ -315,7 +315,7 @@ function SDL_SecbooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; value
  *
  * \sa SDL_GetPropertyType
   }
-function SDL_HasProperty(props: TSDL_PropertiesID; name: PAnsiChar): cbool; cdecl;
+function SDL_HasProperty(props: TSDL_PropertiesID; name: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -358,7 +358,7 @@ function SDL_GetPropertyType(props: TSDL_PropertiesID; name: PAnsiChar): TSDL_Pr
  *
  * \since This function is available since SDL 3.1.3.
  *
- * \sa SDL_GecbooleanProperty
+ * \sa SDL_GetBooleanProperty
  * \sa SDL_GetFloatProperty
  * \sa SDL_GetNumberProperty
  * \sa SDL_GetPropertyType
@@ -460,7 +460,7 @@ function SDL_GetFloatProperty(props: TSDL_PropertiesID; name: PAnsiChar; default
  * \sa SDL_HasProperty
  * \sa SDL_SetBooleanProperty
   }
-function SDL_GetBooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; default_value: cbool): cbool; cdecl;
+function SDL_GetBooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; default_value: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetBooleanProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -475,7 +475,7 @@ function SDL_GetBooleanProperty(props: TSDL_PropertiesID; name: PAnsiChar; defau
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ClearProperty(props: TSDL_PropertiesID; name: PAnsiChar): cbool; cdecl;
+function SDL_ClearProperty(props: TSDL_PropertiesID; name: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearProperty' {$ENDIF} {$ENDIF};
 
 {*
@@ -514,7 +514,7 @@ type
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_EnumerateProperties(props: TSDL_PropertiesID; callback: TSDL_EnumeratePropertiesCallback; userdata: Pointer): cbool; cdecl;
+function SDL_EnumerateProperties(props: TSDL_PropertiesID; callback: TSDL_EnumeratePropertiesCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EnumerateProperties' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_rect.inc
+++ b/units/SDL_rect.inc
@@ -125,7 +125,7 @@ procedure SDL_RectToFRect(const rect: PSDL_Rect; frect: PSDL_FRect); inline;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): cbool; inline;
+function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean; inline;
 
 {*
  * Determine whether a rectangle has no area.
@@ -145,7 +145,7 @@ function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): cbool; inline
  *
  * \since This function is available since SDL 3.1.3.
   }
-function  SDL_RectEmpty(const r: PSDL_Rect): cbool; inline;
+function SDL_RectEmpty(const r: PSDL_Rect): Boolean; inline;
 
 {*
  * Determine whether two rectangles are equal.
@@ -166,7 +166,7 @@ function  SDL_RectEmpty(const r: PSDL_Rect): cbool; inline;
  *
  * \since This function is available since SDL 3.1.3.
   }
- function SDL_RectsEqual(const a: PSDL_Rect; const b: PSDL_Rect): cbool; inline;
+ function SDL_RectsEqual(const a: PSDL_Rect; const b: PSDL_Rect): Boolean; inline;
 
 {*
  * Determine whether two rectangles intersect.
@@ -183,7 +183,7 @@ function  SDL_RectEmpty(const r: PSDL_Rect): cbool; inline;
  *
  * \sa SDL_GetRectIntersection
   }
-function SDL_HasRectIntersection(A: PSDL_Rect; B: PSDL_Rect): cbool; cdecl;
+function SDL_HasRectIntersection(A: PSDL_Rect; B: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasRectIntersection' {$ENDIF} {$ENDIF};
 
 {*
@@ -201,7 +201,7 @@ function SDL_HasRectIntersection(A: PSDL_Rect; B: PSDL_Rect): cbool; cdecl;
  *
  * \sa SDL_HasRectIntersection
   }
-function SDL_GetRectIntersection(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect): cbool; cdecl;
+function SDL_GetRectIntersection(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectIntersection' {$ENDIF} {$ENDIF};
 
 {*
@@ -216,7 +216,7 @@ function SDL_GetRectIntersection(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect):
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectUnion(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect): cbool; cdecl;
+function SDL_GetRectUnion(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectUnion' {$ENDIF} {$ENDIF};
 
 {*
@@ -236,7 +236,7 @@ function SDL_GetRectUnion(A: PSDL_Rect; B: PSDL_Rect; result: PSDL_Rect): cbool;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectEnclosingPoints(points: PSDL_Point; count: cint; clip: PSDL_Rect; result: PSDL_Rect): cbool; cdecl;
+function SDL_GetRectEnclosingPoints(points: PSDL_Point; count: cint; clip: PSDL_Rect; result: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectEnclosingPoints' {$ENDIF} {$ENDIF};
 
 {*
@@ -257,7 +257,7 @@ function SDL_GetRectEnclosingPoints(points: PSDL_Point; count: cint; clip: PSDL_
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectAndLineIntersection(rect: PSDL_Rect; X1: pcint; Y1: pcint; X2: pcint; Y2: pcint): cbool; cdecl;
+function SDL_GetRectAndLineIntersection(rect: PSDL_Rect; X1: pcint; Y1: pcint; X2: pcint; Y2: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectAndLineIntersection' {$ENDIF} {$ENDIF};
 
 { SDL_FRect versions...  }
@@ -283,7 +283,7 @@ function SDL_GetRectAndLineIntersection(rect: PSDL_Rect; X1: pcint; Y1: pcint; X
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_PointInRectFloat(const p: PSDL_FPoint; const r: PSDL_FRect): cbool; inline;
+function SDL_PointInRectFloat(const p: PSDL_FPoint; const r: PSDL_FRect): Boolean; inline;
 
 {*
  * Determine whether a floating point rectangle can contain any point.
@@ -303,7 +303,7 @@ function SDL_PointInRectFloat(const p: PSDL_FPoint; const r: PSDL_FRect): cbool;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_RectEmptyFloat(const r: PSDL_FRect): cbool; inline;
+function SDL_RectEmptyFloat(const r: PSDL_FRect): Boolean; inline;
 
 {*
  * Determine whether two floating point rectangles are equal, within some
@@ -330,7 +330,7 @@ function SDL_RectEmptyFloat(const r: PSDL_FRect): cbool; inline;
  *
  * \sa SDL_RectsEqualFloat
   }
-function SDL_RectsEqualEpsilon(const a: PSDL_Frect; const b: PSDL_FRect; const epsilon: cfloat): cbool; inline;
+function SDL_RectsEqualEpsilon(const a: PSDL_Frect; const b: PSDL_FRect; const epsilon: cfloat): Boolean; inline;
 
 {*
  * Determine whether two floating point rectangles are equal, within a default
@@ -357,7 +357,7 @@ function SDL_RectsEqualEpsilon(const a: PSDL_Frect; const b: PSDL_FRect; const e
  *
  * \sa SDL_RectsEqualEpsilon
   }
-function SDL_RectsEqualFloat(const a: PSDL_FRect; b: PSDL_FRect): cbool; inline;
+function SDL_RectsEqualFloat(const a: PSDL_FRect; b: PSDL_FRect): Boolean; inline;
 
 {*
  * Determine whether two rectangles intersect with float precision.
@@ -372,7 +372,7 @@ function SDL_RectsEqualFloat(const a: PSDL_FRect; b: PSDL_FRect): cbool; inline;
  *
  * \sa SDL_GetRectIntersection
   }
-function SDL_HasRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect): cbool; cdecl;
+function SDL_HasRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasRectIntersectionFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -390,7 +390,7 @@ function SDL_HasRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect): cbool; cdec
  *
  * \sa SDL_HasRectIntersectionFloat
   }
-function SDL_GetRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL_FRect): cbool; cdecl;
+function SDL_GetRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectIntersectionFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -405,7 +405,7 @@ function SDL_GetRectIntersectionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectUnionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL_FRect): cbool; cdecl;
+function SDL_GetRectUnionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectUnionFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -426,7 +426,7 @@ function SDL_GetRectUnionFloat(A: PSDL_FRect; B: PSDL_FRect; result: PSDL_FRect)
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectEnclosingPointsFloat(points: PSDL_FPoint; count: cint; clip: PSDL_FRect; result: PSDL_FRect): cbool; cdecl;
+function SDL_GetRectEnclosingPointsFloat(points: PSDL_FPoint; count: cint; clip: PSDL_FRect; result: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectEnclosingPointsFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -448,7 +448,7 @@ function SDL_GetRectEnclosingPointsFloat(points: PSDL_FPoint; count: cint; clip:
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRectAndLineIntersectionFloat(rect: PSDL_FRect; X1: pcfloat; Y1: pcfloat; X2: pcfloat; Y2: pcfloat): cbool; cdecl;
+function SDL_GetRectAndLineIntersectionFloat(rect: PSDL_FRect; X1: pcfloat; Y1: pcfloat; X2: pcfloat; Y2: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRectAndLineIntersectionFloat' {$ENDIF} {$ENDIF};
 
 

--- a/units/SDL_render.inc
+++ b/units/SDL_render.inc
@@ -186,7 +186,7 @@ function SDL_GetRenderDriver(index: cint): PAnsiChar; cdecl;
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateWindow
   }
-function SDL_CreateWindowAndRenderer(title: PAnsiChar; width: cint; height: cint; window_flags: TSDL_WindowFlags; window: PPSDL_Window; renderer: PPSDL_Renderer): cbool; cdecl;
+function SDL_CreateWindowAndRenderer(title: PAnsiChar; width: cint; height: cint; window_flags: TSDL_WindowFlags; window: PPSDL_Window; renderer: PPSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CreateWindowAndRenderer' {$ENDIF} {$ENDIF};
 
 {*
@@ -481,7 +481,7 @@ const
  *
  * \sa SDL_GetCurrentRenderOutputSize
   }
-function SDL_GetRenderOutputSize(renderer: PSDL_Renderer; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetRenderOutputSize(renderer: PSDL_Renderer; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderOutputSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -504,7 +504,7 @@ function SDL_GetRenderOutputSize(renderer: PSDL_Renderer; w: pcint; h: pcint): c
  *
  * \sa SDL_GetRenderOutputSize
   }
-function SDL_GetCurrentRenderOutputSize(renderer: PSDL_Renderer; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetCurrentRenderOutputSize(renderer: PSDL_Renderer; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetCurrentRenderOutputSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -861,7 +861,7 @@ function SDL_GetRendererFromTexture(texture: PSDL_Texture): PSDL_Renderer; cdecl
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetTextureSize(texture: PSDL_Texture; w: pcfloat; h: pcfloat): cbool; cdecl;
+function SDL_GetTextureSize(texture: PSDL_Texture; w: pcfloat; h: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -891,7 +891,7 @@ function SDL_GetTextureSize(texture: PSDL_Texture; w: pcfloat; h: pcfloat): cboo
  * \sa SDL_SetTextureAlphaMod
  * \sa SDL_SetTextureColorModFloat
   }
-function SDL_SetTextureColorMod(texture: PSDL_Texture; r: cuint8; g: cuint8; b: cuint8): cbool; cdecl;
+function SDL_SetTextureColorMod(texture: PSDL_Texture; r: cuint8; g: cuint8; b: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureColorMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -921,7 +921,7 @@ function SDL_SetTextureColorMod(texture: PSDL_Texture; r: cuint8; g: cuint8; b: 
  * \sa SDL_SetTextureAlphaModFloat
  * \sa SDL_SetTextureColorMod
   }
-function SDL_SetTextureColorModFloat(texture: PSDL_Texture; r: cfloat; g: cfloat; b: cfloat): cbool; cdecl;
+function SDL_SetTextureColorModFloat(texture: PSDL_Texture; r: cfloat; g: cfloat; b: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureColorModFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -942,7 +942,7 @@ function SDL_SetTextureColorModFloat(texture: PSDL_Texture; r: cfloat; g: cfloat
  * \sa SDL_GetTextureColorModFloat
  * \sa SDL_SetTextureColorMod
   }
-function SDL_GetTextureColorMod(texture: PSDL_Texture; r: pcuint8; g: pcuint8; b: pcuint8): cbool; cdecl;
+function SDL_GetTextureColorMod(texture: PSDL_Texture; r: pcuint8; g: pcuint8; b: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureColorMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -963,7 +963,7 @@ function SDL_GetTextureColorMod(texture: PSDL_Texture; r: pcuint8; g: pcuint8; b
  * \sa SDL_GetTextureColorMod
  * \sa SDL_SetTextureColorModFloat
   }
-function SDL_GetTextureColorModFloat(texture: PSDL_Texture; r: pcfloat; g: pcfloat; b: pcfloat): cbool; cdecl;
+function SDL_GetTextureColorModFloat(texture: PSDL_Texture; r: pcfloat; g: pcfloat; b: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureColorModFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -990,7 +990,7 @@ function SDL_GetTextureColorModFloat(texture: PSDL_Texture; r: pcfloat; g: pcflo
  * \sa SDL_SetTextureAlphaModFloat
  * \sa SDL_SetTextureColorMod
   }
-function SDL_SetTextureAlphaMod(texture: PSDL_Texture; alpha: cuint8): cbool; cdecl;
+function SDL_SetTextureAlphaMod(texture: PSDL_Texture; alpha: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureAlphaMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -1017,7 +1017,7 @@ function SDL_SetTextureAlphaMod(texture: PSDL_Texture; alpha: cuint8): cbool; cd
  * \sa SDL_SetTextureAlphaMod
  * \sa SDL_SetTextureColorModFloat
   }
-function SDL_SetTextureAlphaModFloat(texture: PSDL_Texture; alpha: cfloat): cbool; cdecl;
+function SDL_SetTextureAlphaModFloat(texture: PSDL_Texture; alpha: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureAlphaModFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1036,7 +1036,7 @@ function SDL_SetTextureAlphaModFloat(texture: PSDL_Texture; alpha: cfloat): cboo
  * \sa SDL_GetTextureColorMod
  * \sa SDL_SetTextureAlphaMod
   }
-function SDL_GetTextureAlphaMod(texture: PSDL_Texture; alpha: pcuint8): cbool; cdecl;
+function SDL_GetTextureAlphaMod(texture: PSDL_Texture; alpha: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureAlphaMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -1055,7 +1055,7 @@ function SDL_GetTextureAlphaMod(texture: PSDL_Texture; alpha: pcuint8): cbool; c
  * \sa SDL_GetTextureColorModFloat
  * \sa SDL_SetTextureAlphaModFloat
   }
-function SDL_GetTextureAlphaModFloat(texture: PSDL_Texture; alpha: pcfloat): cbool; cdecl;
+function SDL_GetTextureAlphaModFloat(texture: PSDL_Texture; alpha: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureAlphaModFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1075,7 +1075,7 @@ function SDL_GetTextureAlphaModFloat(texture: PSDL_Texture; alpha: pcfloat): cbo
  *
  * \sa SDL_GetTextureBlendMode
   }
-function SDL_SetTextureBlendMode(texture: PSDL_Texture; blendMode: TSDL_BlendMode): cbool; cdecl;
+function SDL_SetTextureBlendMode(texture: PSDL_Texture; blendMode: TSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1092,7 +1092,7 @@ function SDL_SetTextureBlendMode(texture: PSDL_Texture; blendMode: TSDL_BlendMod
  *
  * \sa SDL_SetTextureBlendMode
   }
-function SDL_GetTextureBlendMode(texture: PSDL_Texture; blendMode: PSDL_BlendMode): cbool; cdecl;
+function SDL_GetTextureBlendMode(texture: PSDL_Texture; blendMode: PSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1113,7 +1113,7 @@ function SDL_GetTextureBlendMode(texture: PSDL_Texture; blendMode: PSDL_BlendMod
  *
  * \sa SDL_GetTextureScaleMode
   }
-function SDL_SetTextureScaleMode(texture: PSDL_Texture; scaleMode: TSDL_ScaleMode): cbool; cdecl;
+function SDL_SetTextureScaleMode(texture: PSDL_Texture; scaleMode: TSDL_ScaleMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTextureScaleMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1130,7 +1130,7 @@ function SDL_SetTextureScaleMode(texture: PSDL_Texture; scaleMode: TSDL_ScaleMod
  *
  * \sa SDL_SetTextureScaleMode
   }
-function SDL_GetTextureScaleMode(texture: PSDL_Texture; scaleMode: PSDL_ScaleMode): cbool; cdecl;
+function SDL_GetTextureScaleMode(texture: PSDL_Texture; scaleMode: PSDL_ScaleMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTextureScaleMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1165,7 +1165,7 @@ function SDL_GetTextureScaleMode(texture: PSDL_Texture; scaleMode: PSDL_ScaleMod
  * \sa SDL_UpdateNVTexture
  * \sa SDL_UpdateYUVTexture
   }
-function SDL_UpdateTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: pointer; pitch: cint): cbool; cdecl;
+function SDL_UpdateTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: pointer; pitch: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -1201,7 +1201,7 @@ function SDL_UpdateTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: point
 function SDL_UpdateYUVTexture(texture: PSDL_Texture; rect: PSDL_Rect;
            Yplane: pcuint8; Ypitch: cint;
            Uplane: pcuint8; Upitch: cint;
-           Vplane: pcuint8; Vpitch: cint): cbool; cdecl;
+           Vplane: pcuint8; Vpitch: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateYUVTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -1232,7 +1232,7 @@ function SDL_UpdateYUVTexture(texture: PSDL_Texture; rect: PSDL_Rect;
   }
 function SDL_UpdateNVTexture(texture: PSDL_Texture; rect: PSDL_Rect;
            Yplane: pcuint8; Ypitch: cint;
-           UVplane: pcuint8; UVpitch: cint): cbool; cdecl;
+           UVplane: pcuint8; UVpitch: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateNVTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -1265,7 +1265,7 @@ function SDL_UpdateNVTexture(texture: PSDL_Texture; rect: PSDL_Rect;
  * \sa SDL_LockTextureToSurface
  * \sa SDL_UnlockTexture
   }
-function SDL_LockTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: PPointer; pitch: pcint): cbool; cdecl;
+function SDL_LockTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: PPointer; pitch: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LockTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -1302,7 +1302,7 @@ function SDL_LockTexture(texture: PSDL_Texture; rect: PSDL_Rect; pixels: PPointe
  * \sa SDL_LockTexture
  * \sa SDL_UnlockTexture
   }
-function SDL_LockTextureToSurface(texture: PSDL_Texture; rect: PSDL_Rect; surface: PPSDL_Surface): cbool; cdecl;
+function SDL_LockTextureToSurface(texture: PSDL_Texture; rect: PSDL_Rect; surface: PPSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LockTextureToSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -1347,7 +1347,7 @@ procedure SDL_UnlockTexture(texture: PSDL_Texture); cdecl;
  *
  * \sa SDL_GetRenderTarget
   }
-function SDL_SetRenderTarget(renderer: PSDL_Renderer; texture: PSDL_Texture): cbool; cdecl;
+function SDL_SetRenderTarget(renderer: PSDL_Renderer; texture: PSDL_Texture): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderTarget' {$ENDIF} {$ENDIF};
 
 {*
@@ -1407,7 +1407,7 @@ function SDL_GetRenderTarget(renderer: PSDL_Renderer): PSDL_Texture; cdecl;
  * \sa SDL_GetRenderLogicalPresentation
  * \sa SDL_GetRenderLogicalPresentationRect
   }
-function SDL_SetRenderLogicalPresentation(renderer: PSDL_Renderer; w: cint; h: cint; mode: TSDL_RendererLogicalPresentation): cbool; cdecl;
+function SDL_SetRenderLogicalPresentation(renderer: PSDL_Renderer; w: cint; h: cint; mode: TSDL_RendererLogicalPresentation): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderLogicalPresentation' {$ENDIF} {$ENDIF};
 
 {*
@@ -1429,7 +1429,7 @@ function SDL_SetRenderLogicalPresentation(renderer: PSDL_Renderer; w: cint; h: c
  *
  * \sa SDL_SetRenderLogicalPresentation
   }
-function SDL_GetRenderLogicalPresentation(renderer: PSDL_Renderer; w: pcint; h: pcint; mode: PSDL_RendererLogicalPresentation): cbool; cdecl;
+function SDL_GetRenderLogicalPresentation(renderer: PSDL_Renderer; w: pcint; h: pcint; mode: PSDL_RendererLogicalPresentation): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderLogicalPresentation' {$ENDIF} {$ENDIF};
 
 {*
@@ -1452,7 +1452,7 @@ function SDL_GetRenderLogicalPresentation(renderer: PSDL_Renderer; w: pcint; h: 
  *
  * \sa SDL_SetRenderLogicalPresentation
   }
-function SDL_GetRenderLogicalPresentationRect(renderer: PSDL_Renderer; rect: PSDL_FRect): cbool; cdecl;
+function SDL_GetRenderLogicalPresentationRect(renderer: PSDL_Renderer; rect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderLogicalPresentationRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1480,7 +1480,7 @@ function SDL_GetRenderLogicalPresentationRect(renderer: PSDL_Renderer; rect: PSD
  * \sa SDL_SetRenderLogicalPresentation
  * \sa SDL_SetRenderScale
   }
-function SDL_RenderCoordinatesFromWindow(renderer: PSDL_Renderer; window_x: cfloat; window_y: cfloat; x: pcfloat; y: pcfloat): cbool; cdecl;
+function SDL_RenderCoordinatesFromWindow(renderer: PSDL_Renderer; window_x: cfloat; window_y: cfloat; x: pcfloat; y: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderCoordinatesFromWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -1511,7 +1511,7 @@ function SDL_RenderCoordinatesFromWindow(renderer: PSDL_Renderer; window_x: cflo
  * \sa SDL_SetRenderScale
  * \sa SDL_SetRenderViewport
   }
-function SDL_RenderCoordinatesToWindow(renderer: PSDL_Renderer; x: cfloat; y: cfloat; window_x: pcfloat; window_y: pcfloat): cbool; cdecl;
+function SDL_RenderCoordinatesToWindow(renderer: PSDL_Renderer; x: cfloat; y: cfloat; window_x: pcfloat; window_y: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderCoordinatesToWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -1540,7 +1540,7 @@ function SDL_RenderCoordinatesToWindow(renderer: PSDL_Renderer; x: cfloat; y: cf
  *
  * \sa SDL_RenderCoordinatesFromWindow
   }
-function SDL_ConvertEventToRenderCoordinates(renderer: PSDL_Renderer; event: PSDL_Event): cbool; cdecl;
+function SDL_ConvertEventToRenderCoordinates(renderer: PSDL_Renderer; event: PSDL_Event): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ConvertEventToRenderCoordinates' {$ENDIF} {$ENDIF};
 
 {*
@@ -1565,7 +1565,7 @@ function SDL_ConvertEventToRenderCoordinates(renderer: PSDL_Renderer; event: PSD
  * \sa SDL_GetRenderViewport
  * \sa SDL_RenderViewportSet
   }
-function SDL_SetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool; cdecl;
+function SDL_SetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderViewport' {$ENDIF} {$ENDIF};
 
 {*
@@ -1583,7 +1583,7 @@ function SDL_SetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool;
  * \sa SDL_RenderViewportSet
  * \sa SDL_SetRenderViewport
   }
-function SDL_GetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderViewport' {$ENDIF} {$ENDIF};
 
 {*
@@ -1604,7 +1604,7 @@ function SDL_GetRenderViewport(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool;
  * \sa SDL_GetRenderViewport
  * \sa SDL_SetRenderViewport
   }
-function SDL_RenderViewportSet(renderer: PSDL_Renderer): cbool; cdecl;
+function SDL_RenderViewportSet(renderer: PSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderViewportSet' {$ENDIF} {$ENDIF};
 
 {*
@@ -1627,7 +1627,7 @@ function SDL_RenderViewportSet(renderer: PSDL_Renderer): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetRenderSafeArea(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetRenderSafeArea(renderer: PSDL_Renderer; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderSafeArea' {$ENDIF} {$ENDIF};
 
 {*
@@ -1646,7 +1646,7 @@ function SDL_GetRenderSafeArea(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool;
  * \sa SDL_GetRenderClipRect
  * \sa SDL_RenderClipEnabled
   }
-function SDL_SetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool; cdecl;
+function SDL_SetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderClipRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1665,7 +1665,7 @@ function SDL_SetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool;
  * \sa SDL_RenderClipEnabled
  * \sa SDL_SetRenderClipRect
   }
-function SDL_GetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderClipRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1682,7 +1682,7 @@ function SDL_GetRenderClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): cbool;
  * \sa SDL_GetRenderClipRect
  * \sa SDL_SetRenderClipRect
   }
-function SDL_RenderClipEnabled(renderer: PSDL_Renderer): cbool; cdecl;
+function SDL_RenderClipEnabled(renderer: PSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderClipEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1708,7 +1708,7 @@ function SDL_RenderClipEnabled(renderer: PSDL_Renderer): cbool; cdecl;
  *
  * \sa SDL_GetRenderScale
   }
-function SDL_SetRenderScale(renderer: PSDL_Renderer; scaleX: cfloat; scaleY: cfloat): cbool; cdecl;
+function SDL_SetRenderScale(renderer: PSDL_Renderer; scaleX: cfloat; scaleY: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderScale' {$ENDIF} {$ENDIF};
 
 {*
@@ -1726,7 +1726,7 @@ function SDL_SetRenderScale(renderer: PSDL_Renderer; scaleX: cfloat; scaleY: cfl
  *
  * \sa SDL_SetRenderScale
   }
-function SDL_GetRenderScale(renderer: PSDL_Renderer; scaleX: pcfloat; scaleY: pcfloat): cbool; cdecl;
+function SDL_GetRenderScale(renderer: PSDL_Renderer; scaleX: pcfloat; scaleY: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderScale' {$ENDIF} {$ENDIF};
 
 {*
@@ -1752,7 +1752,7 @@ function SDL_GetRenderScale(renderer: PSDL_Renderer; scaleX: pcfloat; scaleY: pc
  * \sa SDL_GetRenderDrawColor
  * \sa SDL_SetRenderDrawColorFloat
   }
-function SDL_SetRenderDrawColor(renderer: PSDL_Renderer; r: cuint8; g: cuint8; b: cuint8; a: cuint8): cbool; cdecl;
+function SDL_SetRenderDrawColor(renderer: PSDL_Renderer; r: cuint8; g: cuint8; b: cuint8; a: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderDrawColor' {$ENDIF} {$ENDIF};
 
 {*
@@ -1778,7 +1778,7 @@ function SDL_SetRenderDrawColor(renderer: PSDL_Renderer; r: cuint8; g: cuint8; b
  * \sa SDL_GetRenderDrawColorFloat
  * \sa SDL_SetRenderDrawColor
   }
-function SDL_SetRenderDrawColorFloat(renderer: PSDL_Renderer; r: cfloat; g: cfloat; b: cfloat; a: cfloat): cbool; cdecl;
+function SDL_SetRenderDrawColorFloat(renderer: PSDL_Renderer; r: cfloat; g: cfloat; b: cfloat; a: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderDrawColorFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1803,7 +1803,7 @@ function SDL_SetRenderDrawColorFloat(renderer: PSDL_Renderer; r: cfloat; g: cflo
  * \sa SDL_GetRenderDrawColorFloat
  * \sa SDL_SetRenderDrawColor
   }
-function SDL_GetRenderDrawColor(renderer: PSDL_Renderer; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): cbool; cdecl;
+function SDL_GetRenderDrawColor(renderer: PSDL_Renderer; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderDrawColor' {$ENDIF} {$ENDIF};
 
 {*
@@ -1828,7 +1828,7 @@ function SDL_GetRenderDrawColor(renderer: PSDL_Renderer; r: pcuint8; g: pcuint8;
  * \sa SDL_SetRenderDrawColorFloat
  * \sa SDL_GetRenderDrawColor
   }
-function SDL_GetRenderDrawColorFloat(renderer: PSDL_Renderer; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): cbool; cdecl;
+function SDL_GetRenderDrawColorFloat(renderer: PSDL_Renderer; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderDrawColorFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1853,7 +1853,7 @@ function SDL_GetRenderDrawColorFloat(renderer: PSDL_Renderer; r: pcfloat; g: pcf
  *
  * \sa SDL_GetRenderColorScale
   }
-function SDL_SetRenderColorScale(renderer: PSDL_Renderer; scale: cfloat): cbool; cdecl;
+function SDL_SetRenderColorScale(renderer: PSDL_Renderer; scale: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderColorScale' {$ENDIF} {$ENDIF};
 
 {*
@@ -1870,7 +1870,7 @@ function SDL_SetRenderColorScale(renderer: PSDL_Renderer; scale: cfloat): cbool;
  *
  * \sa SDL_SetRenderColorScale
   }
-function SDL_GetRenderColorScale(renderer: PSDL_Renderer; scale: pcfloat): cbool; cdecl;
+function SDL_GetRenderColorScale(renderer: PSDL_Renderer; scale: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderColorScale' {$ENDIF} {$ENDIF};
 
 {*
@@ -1889,7 +1889,7 @@ function SDL_GetRenderColorScale(renderer: PSDL_Renderer; scale: pcfloat): cbool
  *
  * \sa SDL_GetRenderDrawBlendMode
   }
-function SDL_SetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: TSDL_BlendMode): cbool; cdecl;
+function SDL_SetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: TSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderDrawBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1906,7 +1906,7 @@ function SDL_SetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: TSDL_Ble
  *
  * \sa SDL_SetRenderDrawBlendMode
   }
-function SDL_GetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: PSDL_BlendMode): cbool; cdecl;
+function SDL_GetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: PSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderDrawBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1927,7 +1927,7 @@ function SDL_GetRenderDrawBlendMode(renderer: PSDL_Renderer; blendMode: PSDL_Ble
  *
  * \sa SDL_SetRenderDrawColor
   }
-function SDL_RenderClear(renderer: PSDL_Renderer): cbool; cdecl;
+function SDL_RenderClear(renderer: PSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderClear' {$ENDIF} {$ENDIF};
 
 {*
@@ -1945,7 +1945,7 @@ function SDL_RenderClear(renderer: PSDL_Renderer): cbool; cdecl;
  *
  * \sa SDL_RenderPoints
   }
-function SDL_RenderPoint(renderer: PSDL_Renderer; x: cfloat; y: cfloat): cbool; cdecl;
+function SDL_RenderPoint(renderer: PSDL_Renderer; x: cfloat; y: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderPoint' {$ENDIF} {$ENDIF};
 
 {*
@@ -1963,7 +1963,7 @@ function SDL_RenderPoint(renderer: PSDL_Renderer; x: cfloat; y: cfloat): cbool; 
  *
  * \sa SDL_RenderPoint
   }
-function SDL_RenderPoints(renderer: PSDL_Renderer; points: PSDL_FPoint; count: cint): cbool; cdecl;
+function SDL_RenderPoints(renderer: PSDL_Renderer; points: PSDL_FPoint; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderPoints' {$ENDIF} {$ENDIF};
 
 {*
@@ -1983,7 +1983,7 @@ function SDL_RenderPoints(renderer: PSDL_Renderer; points: PSDL_FPoint; count: c
  *
  * \sa SDL_RenderLines
   }
-function SDL_RenderLine(renderer: PSDL_Renderer; x1: cfloat; y1: cfloat; x2: cfloat; y2: cfloat): cbool; cdecl;
+function SDL_RenderLine(renderer: PSDL_Renderer; x1: cfloat; y1: cfloat; x2: cfloat; y2: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderLine' {$ENDIF} {$ENDIF};
 
 {*
@@ -2002,7 +2002,7 @@ function SDL_RenderLine(renderer: PSDL_Renderer; x1: cfloat; y1: cfloat; x2: cfl
  *
  * \sa SDL_RenderLine
   }
-function SDL_RenderLines(renderer: PSDL_Renderer; points: PSDL_FPoint; count: cint): cbool; cdecl;
+function SDL_RenderLines(renderer: PSDL_Renderer; points: PSDL_FPoint; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderLines' {$ENDIF} {$ENDIF};
 
 {*
@@ -2020,7 +2020,7 @@ function SDL_RenderLines(renderer: PSDL_Renderer; points: PSDL_FPoint; count: ci
  *
  * \sa SDL_RenderRects
   }
-function SDL_RenderRect(renderer: PSDL_Renderer; rect: PSDL_FRect): cbool; cdecl;
+function SDL_RenderRect(renderer: PSDL_Renderer; rect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -2039,7 +2039,7 @@ function SDL_RenderRect(renderer: PSDL_Renderer; rect: PSDL_FRect): cbool; cdecl
  *
  * \sa SDL_RenderRect
   }
-function SDL_RenderRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: cint): cbool; cdecl;
+function SDL_RenderRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderRects' {$ENDIF} {$ENDIF};
 
 {*
@@ -2059,7 +2059,7 @@ function SDL_RenderRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: cint
  * \sa SDL_RenderFillRects
   }
 
-function SDL_RenderFillRect(renderer: PSDL_Renderer; rect: PSDL_FRect): cbool; cdecl;
+function SDL_RenderFillRect(renderer: PSDL_Renderer; rect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderFillRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -2078,7 +2078,7 @@ function SDL_RenderFillRect(renderer: PSDL_Renderer; rect: PSDL_FRect): cbool; c
  *
  * \sa SDL_RenderFillRect
   }
-function SDL_RenderFillRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: cint): cbool; cdecl;
+function SDL_RenderFillRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderFillRects' {$ENDIF} {$ENDIF};
 
 {*
@@ -2101,7 +2101,7 @@ function SDL_RenderFillRects(renderer: PSDL_Renderer; rects: PSDL_FRect; count: 
  * \sa SDL_RenderTextureRotated
  * \sa SDL_RenderTextureTiled
   }
-function SDL_RenderTexture(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; dstrect: PSDL_FRect): cbool; cdecl;
+function SDL_RenderTexture(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; dstrect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderTexture' {$ENDIF} {$ENDIF};
 
 {*
@@ -2133,7 +2133,7 @@ function SDL_RenderTexture(renderer: PSDL_Renderer; texture: PSDL_Texture; srcre
 function SDL_RenderTextureRotated(renderer: PSDL_Renderer; texture: PSDL_Texture;
            srcrect: PSDL_FRect; dstrect: PSDL_FRect;
            angle: cdouble; center: PSDL_FPoint;
-           flip: TSDL_FlipMode): cbool; cdecl;
+           flip: TSDL_FlipMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderTextureRotated' {$ENDIF} {$ENDIF};
 
 {*
@@ -2161,7 +2161,7 @@ function SDL_RenderTextureRotated(renderer: PSDL_Renderer; texture: PSDL_Texture
  *
  * \sa SDL_RenderTexture
   }
-function SDL_RenderTextureTiled(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; scale: cfloat; dstrect: PSDL_FRect): cbool; cdecl;
+function SDL_RenderTextureTiled(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; scale: cfloat; dstrect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderTextureTiled' {$ENDIF} {$ENDIF};
 
 {*
@@ -2196,7 +2196,7 @@ function SDL_RenderTextureTiled(renderer: PSDL_Renderer; texture: PSDL_Texture; 
  *
  * \sa SDL_RenderTexture
   }
-function SDL_RenderTexture9Grid(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; left_width: cfloat; right_width: cfloat; top_height: cfloat; bottom_height: cfloat; scale: cfloat; dstrect: PSDL_FRect): cbool; cdecl;
+function SDL_RenderTexture9Grid(renderer: PSDL_Renderer; texture: PSDL_Texture; srcrect: PSDL_FRect; left_width: cfloat; right_width: cfloat; top_height: cfloat; bottom_height: cfloat; scale: cfloat; dstrect: PSDL_FRect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderTexture9Grid' {$ENDIF} {$ENDIF};
 
 {*
@@ -2221,7 +2221,7 @@ function SDL_RenderTexture9Grid(renderer: PSDL_Renderer; texture: PSDL_Texture; 
  *
  * \sa SDL_RenderGeometryRaw
   }
-function SDL_RenderGeometry(renderer: PSDL_Renderer; texture: PSDL_Texture; vertices: PSDL_Vertex; num_vertices: cint; indices: pcint; num_indices: cint): cbool; cdecl;
+function SDL_RenderGeometry(renderer: PSDL_Renderer; texture: PSDL_Texture; vertices: PSDL_Vertex; num_vertices: cint; indices: pcint; num_indices: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderGeometry' {$ENDIF} {$ENDIF};
 
 {*
@@ -2256,7 +2256,7 @@ function SDL_RenderGeometryRaw(renderer: PSDL_Renderer; texture: PSDL_Texture;
            color: PSDL_FColor; color_stride: cint;
            uv: pcfloat; uv_stride: cint;
            num_vertices: cint;
-           indices: pointer; num_indices: cint; size_indices: cint): cbool; cdecl;
+           indices: pointer; num_indices: cint; size_indices: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderGeometryRaw' {$ENDIF} {$ENDIF};
 
 {*
@@ -2329,7 +2329,7 @@ function SDL_RenderReadPixels(renderer: PSDL_Renderer; rect: PSDL_Rect): PSDL_Su
  * \sa SDL_SetRenderDrawBlendMode
  * \sa SDL_SetRenderDrawColor
   }
-function SDL_RenderPresent(renderer: PSDL_Renderer): cbool; cdecl;
+function SDL_RenderPresent(renderer: PSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderPresent' {$ENDIF} {$ENDIF};
 
 {*
@@ -2398,7 +2398,7 @@ procedure SDL_DestroyRenderer(renderer: PSDL_Renderer); cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_FlushRenderer(renderer: PSDL_Renderer): cbool; cdecl;
+function SDL_FlushRenderer(renderer: PSDL_Renderer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FlushRenderer' {$ENDIF} {$ENDIF};
 
 {*
@@ -2472,7 +2472,7 @@ function SDL_GetRenderMetalCommandEncoder(renderer: PSDL_Renderer): Pointer; cde
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_AddVulkanRenderSemaphores(renderer: PSDL_Renderer; wait_stage_mask: cuint32; wait_semaphore: cint64; signal_semaphore: cint64): cbool; cdecl;
+function SDL_AddVulkanRenderSemaphores(renderer: PSDL_Renderer; wait_stage_mask: cuint32; wait_semaphore: cint64; signal_semaphore: cint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AddVulkanRenderSemaphores' {$ENDIF} {$ENDIF};
 
 {*
@@ -2498,7 +2498,7 @@ function SDL_AddVulkanRenderSemaphores(renderer: PSDL_Renderer; wait_stage_mask:
  *
  * \sa SDL_GetRenderVSync
   }
-function SDL_SetRenderVSync(renderer: PSDL_Renderer; vsync: cint): cbool; cdecl;
+function SDL_SetRenderVSync(renderer: PSDL_Renderer; vsync: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRenderVSync' {$ENDIF} {$ENDIF};
 
 const
@@ -2520,7 +2520,7 @@ const
  *
  * \sa SDL_SetRenderVSync
   }
-function SDL_GetRenderVSync(renderer: PSDL_Renderer; vsync: pcint): cbool; cdecl;
+function SDL_GetRenderVSync(renderer: PSDL_Renderer; vsync: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetRenderVSync' {$ENDIF} {$ENDIF};
 
 {*
@@ -2574,6 +2574,6 @@ const
  *
  * \sa SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE
   }
-function SDL_RenderDebugText(renderer: PSDL_Renderer; x: cfloat; y: cfloat; str: PAnsiChar): cbool; cdecl;
+function SDL_RenderDebugText(renderer: PSDL_Renderer; x: cfloat; y: cfloat; str: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderDebugText' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_sensor.inc
+++ b/units/SDL_sensor.inc
@@ -267,7 +267,7 @@ function SDL_GetSensorID(sensor: PSDL_Sensor): TSDL_SensorID; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetSensorData(sensor: PSDL_Sensor; data: pcfloat; num_values: cint): cbool; cdecl;
+function SDL_GetSensorData(sensor: PSDL_Sensor; data: pcfloat; num_values: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSensorData' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_storage.inc
+++ b/units/SDL_storage.inc
@@ -248,17 +248,17 @@ type
   PSDL_StorageInterface = ^TSDL_StorageInterface;
   TSDL_StorageInterface = record
       version: cuint32;                                                                                             { The version of this interface  }
-      close: function(userdata: Pointer): cbool; cdecl;                                                             { Called when the storage is closed  }
-      ready: function(userdata: Pointer): cbool; cdecl;                                                             { Optional, returns whether the storage is currently ready for access  }
+      close: function(userdata: Pointer): Boolean; cdecl;                                                             { Called when the storage is closed  }
+      ready: function(userdata: Pointer): Boolean; cdecl;                                                             { Optional, returns whether the storage is currently ready for access  }
       enumerate: function(userdata: Pointer; path: PAnsiChar; callback: TSDL_EnumerateDirectoryCallback;            { Enumerate a directory, optional for write-only storage  }
-                          callback_userdata: Pointer): cbool; cdecl;
-      info: function(userdata: Pointer; path: PAnsiChar; info: PSDL_PathInfo): cbool; cdecl;                        { Get path information, optional for write-only storage  }
-      read_file: function(userdata: Pointer; path: PAnsiChar; destination: Pointer; length: cuint64): cbool; cdecl; { Read a file from storage, optional for write-only storage  }
-      write_file: function(userdata: Pointer; path: PAnsiChar; source: Pointer; length: cuint64): cbool; cdecl;     { Write a file to storage, optional for read-only storage  }
-      mkdir: function(userdata: Pointer; path: PAnsiChar): cbool; cdecl;                                            { Create a directory, optional for read-only storage  }
-      remove: function(userdata: Pointer; path: PAnsiChar): cbool; cdecl;                                           { Remove a file or empty directory, optional for read-only storage  }
-      rename: function(userdata: Pointer; oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;                    { Rename a path, optional for read-only storage  }
-      copy: function(userdata: Pointer; oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;                      { Copy a file, optional for read-only storage  }
+                          callback_userdata: Pointer): Boolean; cdecl;
+      info: function(userdata: Pointer; path: PAnsiChar; info: PSDL_PathInfo): Boolean; cdecl;                        { Get path information, optional for write-only storage  }
+      read_file: function(userdata: Pointer; path: PAnsiChar; destination: Pointer; length: cuint64): Boolean; cdecl; { Read a file from storage, optional for write-only storage  }
+      write_file: function(userdata: Pointer; path: PAnsiChar; source: Pointer; length: cuint64): Boolean; cdecl;     { Write a file to storage, optional for read-only storage  }
+      mkdir: function(userdata: Pointer; path: PAnsiChar): Boolean; cdecl;                                            { Create a directory, optional for read-only storage  }
+      remove: function(userdata: Pointer; path: PAnsiChar): Boolean; cdecl;                                           { Remove a file or empty directory, optional for read-only storage  }
+      rename: function(userdata: Pointer; oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;                    { Rename a path, optional for read-only storage  }
+      copy: function(userdata: Pointer; oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;                      { Copy a file, optional for read-only storage  }
       space_remaining: function(userdata: Pointer): cuint64; cdecl;                                                 { Get the space remaining, optional for read-only storage  }
     end;
 
@@ -404,7 +404,7 @@ function SDL_OpenStorage(iface: PSDL_StorageInterface; userdata: Pointer): PSDL_
  * \sa SDL_OpenTitleStorage
  * \sa SDL_OpenUserStorage
   }
-function SDL_CloseStorage(storage: PSDL_Storage): cbool; cdecl;
+function SDL_CloseStorage(storage: PSDL_Storage): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CloseStorage' {$ENDIF} {$ENDIF};
 
 {*
@@ -419,7 +419,7 @@ function SDL_CloseStorage(storage: PSDL_Storage): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_StorageReady(storage: PSDL_Storage): cbool; cdecl;
+function SDL_StorageReady(storage: PSDL_Storage): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_StorageReady' {$ENDIF} {$ENDIF};
 
 {*
@@ -436,7 +436,7 @@ function SDL_StorageReady(storage: PSDL_Storage): cbool; cdecl;
  * \sa SDL_ReadStorageFile
  * \sa SDL_StorageReady
   }
-function SDL_GetStorageFileSize(storage: PSDL_Storage; path: PAnsiChar; length: pcuint64): cbool; cdecl;
+function SDL_GetStorageFileSize(storage: PSDL_Storage; path: PAnsiChar; length: pcuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetStorageFileSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -460,7 +460,7 @@ function SDL_GetStorageFileSize(storage: PSDL_Storage; path: PAnsiChar; length: 
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
   }
-function SDL_ReadStorageFile(storage: PSDL_Storage; path: PAnsiChar; destination: Pointer; length: cuint64): cbool; cdecl;
+function SDL_ReadStorageFile(storage: PSDL_Storage; path: PAnsiChar; destination: Pointer; length: cuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadStorageFile' {$ENDIF} {$ENDIF};
 
 {*
@@ -479,7 +479,7 @@ function SDL_ReadStorageFile(storage: PSDL_Storage; path: PAnsiChar; destination
  * \sa SDL_ReadStorageFile
  * \sa SDL_StorageReady
   }
-function SDL_WriteStorageFile(storage: PSDL_Storage; path: PAnsiChar; source: Pointer; length: cuint64): cbool; cdecl;
+function SDL_WriteStorageFile(storage: PSDL_Storage; path: PAnsiChar; source: Pointer; length: cuint64): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteStorageFile' {$ENDIF} {$ENDIF};
 
 {*
@@ -494,7 +494,7 @@ function SDL_WriteStorageFile(storage: PSDL_Storage; path: PAnsiChar; source: Po
  *
  * \sa SDL_StorageReady
   }
-function SDL_CreateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar): cbool; cdecl;
+function SDL_CreateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CreateStorageDirectory' {$ENDIF} {$ENDIF};
 
 {*
@@ -524,7 +524,7 @@ function SDL_CreateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar): cbo
  *
  * \sa SDL_StorageReady
   }
-function SDL_EnumerateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar; callback: TSDL_EnumerateDirectoryCallback; userdata: Pointer): cbool; cdecl;
+function SDL_EnumerateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar; callback: TSDL_EnumerateDirectoryCallback; userdata: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EnumerateStorageDirectory' {$ENDIF} {$ENDIF};
 
 {*
@@ -539,7 +539,7 @@ function SDL_EnumerateStorageDirectory(storage: PSDL_Storage; path: PAnsiChar; c
  *
  * \sa SDL_StorageReady
   }
-function SDL_RemoveStoragePath(storage: PSDL_Storage; path: PAnsiChar): cbool; cdecl;
+function SDL_RemoveStoragePath(storage: PSDL_Storage; path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RemoveStoragePath' {$ENDIF} {$ENDIF};
 
 {*
@@ -555,7 +555,7 @@ function SDL_RemoveStoragePath(storage: PSDL_Storage; path: PAnsiChar): cbool; c
  *
  * \sa SDL_StorageReady
   }
-function SDL_RenameStoragePath(storage: PSDL_Storage; oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
+function SDL_RenameStoragePath(storage: PSDL_Storage; oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenameStoragePath' {$ENDIF} {$ENDIF};
 
 {*
@@ -571,7 +571,7 @@ function SDL_RenameStoragePath(storage: PSDL_Storage; oldpath: PAnsiChar; newpat
  *
  * \sa SDL_StorageReady
   }
-function SDL_CopyStorageFile(storage: PSDL_Storage; oldpath: PAnsiChar; newpath: PAnsiChar): cbool; cdecl;
+function SDL_CopyStorageFile(storage: PSDL_Storage; oldpath: PAnsiChar; newpath: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CopyStorageFile' {$ENDIF} {$ENDIF};
 
 {*
@@ -588,7 +588,7 @@ function SDL_CopyStorageFile(storage: PSDL_Storage; oldpath: PAnsiChar; newpath:
  *
  * \sa SDL_StorageReady
   }
-function SDL_GetStoragePathInfo(storage: PSDL_Storage; path: PAnsiChar; info: PSDL_PathInfo): cbool; cdecl;
+function SDL_GetStoragePathInfo(storage: PSDL_Storage; path: PAnsiChar; info: PSDL_PathInfo): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetStoragePathInfo' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_surface.inc
+++ b/units/SDL_surface.inc
@@ -234,7 +234,7 @@ const
  * \sa SDL_GetSurfaceColorspace
   }
 
-function SDL_SetSurfaceColorspace(surface: PSDL_Surface; colorspace: TSDL_Colorspace): cbool; cdecl;
+function SDL_SetSurfaceColorspace(surface: PSDL_Surface; colorspace: TSDL_Colorspace): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceColorspace' {$ENDIF} {$ENDIF};
 
 {*
@@ -299,7 +299,7 @@ function SDL_CreateSurfacePalette(surface: PSDL_Surface): PSDL_Palette; cdecl;
  * \sa SDL_CreatePalette
  * \sa SDL_GetSurfacePalette
   }
-function SDL_SetSurfacePalette(surface: PSDL_Surface; palette: PSDL_Palette): cbool; cdecl;
+function SDL_SetSurfacePalette(surface: PSDL_Surface; palette: PSDL_Palette): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfacePalette' {$ENDIF} {$ENDIF};
 
 {*
@@ -339,7 +339,7 @@ function SDL_GetSurfacePalette(surface: PSDL_Surface): PSDL_Palette; cdecl;
  * \sa SDL_GetSurfaceImages
  * \sa SDL_SurfaceHasAlternateImages
   }
-function SDL_AddSurfaceAlternateImage(surface: PSDL_Surface; image: PSDL_Surface): cbool; cdecl;
+function SDL_AddSurfaceAlternateImage(surface: PSDL_Surface; image: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_AddSurfaceAlternateImage' {$ENDIF} {$ENDIF};
 
 {*
@@ -354,7 +354,7 @@ function SDL_AddSurfaceAlternateImage(surface: PSDL_Surface; image: PSDL_Surface
  * \sa SDL_RemoveSurfaceAlternateImages
  * \sa SDL_GetSurfaceImages
   }
-function SDL_SurfaceHasAlternateImages(surface: PSDL_Surface): cbool; cdecl;
+function SDL_SurfaceHasAlternateImages(surface: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SurfaceHasAlternateImages' {$ENDIF} {$ENDIF};
 
 {*
@@ -421,7 +421,7 @@ procedure SDL_RemoveSurfaceAlternateImages(surface: PSDL_Surface); cdecl;
  * \sa SDL_MUSTLOCK
  * \sa SDL_UnlockSurface
   }
-function SDL_LockSurface(surface: PSDL_Surface): cbool; cdecl;
+function SDL_LockSurface(surface: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LockSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -454,7 +454,7 @@ procedure SDL_UnlockSurface(surface: PSDL_Surface); cdecl;
  * \sa SDL_LoadBMP
  * \sa SDL_SaveBMP_IO
   }
-function SDL_LoadBMP_IO(src: PSDL_IOStream; closeio: cbool): PSDL_Surface; cdecl;
+function SDL_LoadBMP_IO(src: PSDL_IOStream; closeio: Boolean): PSDL_Surface; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_LoadBMP_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -498,7 +498,7 @@ function SDL_LoadBMP(file_: PAnsiChar): PSDL_Surface; cdecl;
  * \sa SDL_LoadBMP_IO
  * \sa SDL_SaveBMP
   }
-function SDL_SaveBMP_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cbool): cbool; cdecl;
+function SDL_SaveBMP_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SaveBMP_IO' {$ENDIF} {$ENDIF};
 
 {*
@@ -521,7 +521,7 @@ function SDL_SaveBMP_IO(surface: PSDL_Surface; dst: PSDL_IOStream; closeio: cboo
  * \sa SDL_SaveBMP_IO
   }
 
-function SDL_SaveBMP(surface: PSDL_Surface; file_: PAnsiChar): cbool; cdecl;
+function SDL_SaveBMP(surface: PSDL_Surface; file_: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SaveBMP' {$ENDIF} {$ENDIF};
 
 {*
@@ -541,7 +541,7 @@ function SDL_SaveBMP(surface: PSDL_Surface; file_: PAnsiChar): cbool; cdecl;
  * \sa SDL_LockSurface
  * \sa SDL_UnlockSurface
   }
-function SDL_SetSurfaceRLE(surface: PSDL_Surface; enabled: cbool): cbool; cdecl;
+function SDL_SetSurfaceRLE(surface: PSDL_Surface; enabled: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceRLE' {$ENDIF} {$ENDIF};
 
 {*
@@ -556,7 +556,7 @@ function SDL_SetSurfaceRLE(surface: PSDL_Surface; enabled: cbool): cbool; cdecl;
  *
  * \sa SDL_SetSurfaceRLE
   }
-function SDL_SurfaceHasRLE(surface: PSDL_Surface): cbool; cdecl;
+function SDL_SurfaceHasRLE(surface: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SurfaceHasRLE' {$ENDIF} {$ENDIF};
 
 {*
@@ -581,7 +581,7 @@ function SDL_SurfaceHasRLE(surface: PSDL_Surface): cbool; cdecl;
  * \sa SDL_SetSurfaceRLE
  * \sa SDL_SurfaceHasColorKey
   }
-function SDL_SetSurfaceColorKey(surface: PSDL_Surface; enabled: cbool; key: cuint32): cbool; cdecl;
+function SDL_SetSurfaceColorKey(surface: PSDL_Surface; enabled: Boolean; key: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceColorKey' {$ENDIF} {$ENDIF};
 
 {*
@@ -597,7 +597,7 @@ function SDL_SetSurfaceColorKey(surface: PSDL_Surface; enabled: cbool; key: cuin
  * \sa SDL_SetSurfaceColorKey
  * \sa SDL_GetSurfaceColorKey
   }
-function SDL_SurfaceHasColorKey(surface: PSDL_Surface): cbool; cdecl;
+function SDL_SurfaceHasColorKey(surface: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SurfaceHasColorKey' {$ENDIF} {$ENDIF};
 
 {*
@@ -618,7 +618,7 @@ function SDL_SurfaceHasColorKey(surface: PSDL_Surface): cbool; cdecl;
  * \sa SDL_SetSurfaceColorKey
  * \sa SDL_SurfaceHasColorKey
   }
-function SDL_GetSurfaceColorKey(surface: PSDL_Surface; key: pcuint32): cbool; cdecl;
+function SDL_GetSurfaceColorKey(surface: PSDL_Surface; key: pcuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSurfaceColorKey' {$ENDIF} {$ENDIF};
 
 {*
@@ -642,7 +642,7 @@ function SDL_GetSurfaceColorKey(surface: PSDL_Surface; key: pcuint32): cbool; cd
  * \sa SDL_GetSurfaceColorMod
  * \sa SDL_SetSurfaceAlphaMod
   }
-function SDL_SetSurfaceColorMod(surface: PSDL_Surface; r: cuint8; g: cuint8; b: cuint8): cbool; cdecl;
+function SDL_SetSurfaceColorMod(surface: PSDL_Surface; r: cuint8; g: cuint8; b: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceColorMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -660,7 +660,7 @@ function SDL_SetSurfaceColorMod(surface: PSDL_Surface; r: cuint8; g: cuint8; b: 
  * \sa SDL_GetSurfaceAlphaMod
  * \sa SDL_SetSurfaceColorMod
   }
-function SDL_GetSurfaceColorMod(surface: PSDL_Surface; r: pcuint8; g: pcuint8; b: pcuint8): cbool; cdecl;
+function SDL_GetSurfaceColorMod(surface: PSDL_Surface; r: pcuint8; g: pcuint8; b: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSurfaceColorMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -681,7 +681,7 @@ function SDL_GetSurfaceColorMod(surface: PSDL_Surface; r: pcuint8; g: pcuint8; b
  * \sa SDL_GetSurfaceAlphaMod
  * \sa SDL_SetSurfaceColorMod
   }
-function SDL_SetSurfaceAlphaMod(surface: PSDL_Surface; alpha: cuint8): cbool; cdecl;
+function SDL_SetSurfaceAlphaMod(surface: PSDL_Surface; alpha: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceAlphaMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -697,7 +697,7 @@ function SDL_SetSurfaceAlphaMod(surface: PSDL_Surface; alpha: cuint8): cbool; cd
  * \sa SDL_GetSurfaceColorMod
  * \sa SDL_SetSurfaceAlphaMod
   }
-function SDL_GetSurfaceAlphaMod(surface: PSDL_Surface; alpha: pcuint8): cbool; cdecl;
+function SDL_GetSurfaceAlphaMod(surface: PSDL_Surface; alpha: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSurfaceAlphaMod' {$ENDIF} {$ENDIF};
 
 {*
@@ -716,7 +716,7 @@ function SDL_GetSurfaceAlphaMod(surface: PSDL_Surface; alpha: pcuint8): cbool; c
  *
  * \sa SDL_GetSurfaceBlendMode
   }
-function SDL_SetSurfaceBlendMode(surface: PSDL_Surface; blendMode: TSDL_BlendMode): cbool; cdecl;
+function SDL_SetSurfaceBlendMode(surface: PSDL_Surface; blendMode: TSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -731,7 +731,7 @@ function SDL_SetSurfaceBlendMode(surface: PSDL_Surface; blendMode: TSDL_BlendMod
  *
  * \sa SDL_SetSurfaceBlendMode
   }
-function SDL_GetSurfaceBlendMode(surface: PSDL_Surface; blendMode: PSDL_BlendMode): cbool; cdecl;
+function SDL_GetSurfaceBlendMode(surface: PSDL_Surface; blendMode: PSDL_BlendMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSurfaceBlendMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -753,7 +753,7 @@ function SDL_GetSurfaceBlendMode(surface: PSDL_Surface; blendMode: PSDL_BlendMod
  *
  * \sa SDL_GetSurfaceClipRect
   }
-function SDL_SetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): cbool; cdecl;
+function SDL_SetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetSurfaceClipRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -773,7 +773,7 @@ function SDL_SetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): cbool; 
  *
  * \sa SDL_SetSurfaceClipRect
   }
-function SDL_GetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSurfaceClipRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -786,7 +786,7 @@ function SDL_GetSurfaceClipRect(surface: PSDL_Surface; rect: PSDL_Rect): cbool; 
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_FlipSurface(surface: PSDL_Surface; flip: TSDL_FlipMode): cbool; cdecl;
+function SDL_FlipSurface(surface: PSDL_Surface; flip: TSDL_FlipMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FlipSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -901,7 +901,7 @@ function SDL_ConvertSurfaceAndColorspace(surface: PSDL_Surface; format: TSDL_Pix
  *
  * \sa SDL_ConvertPixelsAndColorspace
   }
-function SDL_ConvertPixels(width: cint; height: cint; src_format: TSDL_PixelFormat; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst: Pointer; dst_pitch: cint): cbool; cdecl;
+function SDL_ConvertPixels(width: cint; height: cint; src_format: TSDL_PixelFormat; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst: Pointer; dst_pitch: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ConvertPixels' {$ENDIF} {$ENDIF};
 
 {*
@@ -931,7 +931,7 @@ function SDL_ConvertPixels(width: cint; height: cint; src_format: TSDL_PixelForm
  *
  * \sa SDL_ConvertPixels
   }
-function SDL_ConvertPixelsAndColorspace(width: cint; height: cint; src_format: TSDL_PixelFormat; src_colorspace: TSDL_Colorspace; src_properties: TSDL_PropertiesID; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst_colorspace: TSDL_Colorspace; dst_properties: TSDL_PropertiesID; dst: Pointer; dst_pitch: cint): cbool; cdecl;
+function SDL_ConvertPixelsAndColorspace(width: cint; height: cint; src_format: TSDL_PixelFormat; src_colorspace: TSDL_Colorspace; src_properties: TSDL_PropertiesID; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst_colorspace: TSDL_Colorspace; dst_properties: TSDL_PropertiesID; dst: Pointer; dst_pitch: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ConvertPixelsAndColorspace' {$ENDIF} {$ENDIF};
 
 {*
@@ -954,7 +954,7 @@ function SDL_ConvertPixelsAndColorspace(width: cint; height: cint; src_format: T
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_PremultiplyAlpha(width: cint; height: cint; src_format: TSDL_PixelFormat; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst: Pointer; dst_pitch: cint; linear: cbool): cbool; cdecl;
+function SDL_PremultiplyAlpha(width: cint; height: cint; src_format: TSDL_PixelFormat; src: Pointer; src_pitch: cint; dst_format: TSDL_PixelFormat; dst: Pointer; dst_pitch: cint; linear: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PremultiplyAlpha' {$ENDIF} {$ENDIF};
 
 {*
@@ -970,7 +970,7 @@ function SDL_PremultiplyAlpha(width: cint; height: cint; src_format: TSDL_PixelF
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_PremultiplySurfaceAlpha(surface: PSDL_Surface; linear: cbool): cbool; cdecl;
+function SDL_PremultiplySurfaceAlpha(surface: PSDL_Surface; linear: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_PremultiplySurfaceAlpha' {$ENDIF} {$ENDIF};
 
 {*
@@ -991,7 +991,7 @@ function SDL_PremultiplySurfaceAlpha(surface: PSDL_Surface; linear: cbool): cboo
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ClearSurface(surface: PSDL_Surface; r: cfloat; g: cfloat; b: cfloat; a: cfloat): cbool; cdecl;
+function SDL_ClearSurface(surface: PSDL_Surface; r: cfloat; g: cfloat; b: cfloat; a: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -1017,7 +1017,7 @@ function SDL_ClearSurface(surface: PSDL_Surface; r: cfloat; g: cfloat; b: cfloat
  *
  * \sa SDL_FillSurfaceRects
   }
-function SDL_FillSurfaceRect(dst: PSDL_Surface; rect: PSDL_Rect; color: cuint32): cbool; cdecl;
+function SDL_FillSurfaceRect(dst: PSDL_Surface; rect: PSDL_Rect; color: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FillSurfaceRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -1043,7 +1043,7 @@ function SDL_FillSurfaceRect(dst: PSDL_Surface; rect: PSDL_Rect; color: cuint32)
  *
  * \sa SDL_FillSurfaceRect
   }
-function SDL_FillSurfaceRects(dst: PSDL_Surface; rects: PSDL_Rect; count: cint; color: cuint32): cbool; cdecl;
+function SDL_FillSurfaceRects(dst: PSDL_Surface; rects: PSDL_Rect; count: cint; color: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FillSurfaceRects' {$ENDIF} {$ENDIF};
 
 {*
@@ -1119,7 +1119,7 @@ function SDL_FillSurfaceRects(dst: PSDL_Surface; rects: PSDL_Rect; count: cint; 
  *
  * \sa SDL_BlitSurfaceScaled
   }
-function SDL_BlitSurface(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): cbool; cdecl;
+function SDL_BlitSurface(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -1145,7 +1145,7 @@ function SDL_BlitSurface(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surfac
  *
  * \sa SDL_BlitSurface
   }
-function SDL_BlitSurfaceUnchecked(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): cbool; cdecl;
+function SDL_BlitSurfaceUnchecked(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurfaceUnchecked' {$ENDIF} {$ENDIF};
 
 {*
@@ -1171,7 +1171,7 @@ function SDL_BlitSurfaceUnchecked(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PS
  *
  * \sa SDL_BlitSurface
   }
-function SDL_BlitSurfaceScaled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect; scaleMode: TSDL_ScaleMode): cbool; cdecl;
+function SDL_BlitSurfaceScaled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect; scaleMode: TSDL_ScaleMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurfaceScaled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1198,7 +1198,7 @@ function SDL_BlitSurfaceScaled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_
  *
  * \sa SDL_BlitSurfaceScaled
   }
-function SDL_BlitSurfaceUncheckedScaled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect; scaleMode: TSDL_ScaleMode): cbool; cdecl;
+function SDL_BlitSurfaceUncheckedScaled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect; scaleMode: TSDL_ScaleMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurfaceUncheckedScaled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1225,7 +1225,7 @@ function SDL_BlitSurfaceUncheckedScaled(src: PSDL_Surface; srcrect: PSDL_Rect; d
  *
  * \sa SDL_BlitSurface
   }
-function SDL_BlitSurfaceTiled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): cbool; cdecl;
+function SDL_BlitSurfaceTiled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_Surface; dstrect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurfaceTiled' {$ENDIF} {$ENDIF};
 
 {*
@@ -1256,7 +1256,7 @@ function SDL_BlitSurfaceTiled(src: PSDL_Surface; srcrect: PSDL_Rect; dst: PSDL_S
  *
  * \sa SDL_BlitSurface
   }
-function SDL_BlitSurfaceTiledWithScale(src: PSDL_Surface; srcrect: PSDL_Rect; scale: cfloat; scaleMode: TSDL_ScaleMode; dst: PSDL_Surface; dstrect: PSDL_Rect): cbool; cdecl;
+function SDL_BlitSurfaceTiledWithScale(src: PSDL_Surface; srcrect: PSDL_Rect; scale: cfloat; scaleMode: TSDL_ScaleMode; dst: PSDL_Surface; dstrect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurfaceTiledWithScale' {$ENDIF} {$ENDIF};
 
 {*
@@ -1294,7 +1294,7 @@ function SDL_BlitSurfaceTiledWithScale(src: PSDL_Surface; srcrect: PSDL_Rect; sc
  *
  * \sa SDL_BlitSurface
   }
-function SDL_BlitSurface9Grid(src: PSDL_Surface; srcrect: PSDL_Rect; left_width: cint; right_width: cint; top_height: cint; bottom_height: cint; scale: cfloat; scaleMode: TSDL_ScaleMode; dst: PSDL_Surface; dstrect: PSDL_Rect): cbool; cdecl;
+function SDL_BlitSurface9Grid(src: PSDL_Surface; srcrect: PSDL_Rect; left_width: cint; right_width: cint; top_height: cint; bottom_height: cint; scale: cfloat; scaleMode: TSDL_ScaleMode; dst: PSDL_Surface; dstrect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_BlitSurface9Grid' {$ENDIF} {$ENDIF};
 
 {*
@@ -1385,7 +1385,7 @@ function SDL_MapSurfaceRGBA(surface: PSDL_Surface; r: cuint8; g: cuint8; b: cuin
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ReadSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): cbool; cdecl;
+function SDL_ReadSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: pcuint8; g: pcuint8; b: pcuint8; a: pcuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadSurfacePixel' {$ENDIF} {$ENDIF};
 
 {*
@@ -1410,7 +1410,7 @@ function SDL_ReadSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: pcuint
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ReadSurfacePixelFloat(surface: PSDL_Surface; x: cint; y: cint; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): cbool; cdecl;
+function SDL_ReadSurfacePixelFloat(surface: PSDL_Surface; x: cint; y: cint; r: pcfloat; g: pcfloat; b: pcfloat; a: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ReadSurfacePixelFloat' {$ENDIF} {$ENDIF};
 
 {*
@@ -1434,7 +1434,7 @@ function SDL_ReadSurfacePixelFloat(surface: PSDL_Surface; x: cint; y: cint; r: p
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_WriteSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: cuint8; g: cuint8; b: cuint8; a: cuint8): cbool; cdecl;
+function SDL_WriteSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: cuint8; g: cuint8; b: cuint8; a: cuint8): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteSurfacePixel' {$ENDIF} {$ENDIF};
 
 {*
@@ -1455,6 +1455,6 @@ function SDL_WriteSurfacePixel(surface: PSDL_Surface; x: cint; y: cint; r: cuint
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_WriteSurfacePixelFloat(surface: PSDL_Surface; x: cint; y: cint; r: cfloat; g: cfloat; b: cfloat; a: cfloat): cbool; cdecl;
+function SDL_WriteSurfacePixelFloat(surface: PSDL_Surface; x: cint; y: cint; r: cfloat; g: cfloat; b: cfloat; a: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WriteSurfacePixelFloat' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_thread.inc
+++ b/units/SDL_thread.inc
@@ -435,7 +435,7 @@ function SDL_GetThreadID(thread: PSDL_Thread): TSDL_ThreadID; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_SetCurrentThreadPriority(priority: TSDL_ThreadPriority): cbool; cdecl;
+function SDL_SetCurrentThreadPriority(priority: TSDL_ThreadPriority): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetCurrentThreadPriority' {$ENDIF} {$ENDIF};
 
 {*
@@ -581,7 +581,7 @@ type
  *
  * \sa SDL_GetTLS
   }
-function SDL_SetTLS(id: PSDL_TLSID; value: Pointer; destructor_: TSDL_TLSDestructorCallback): cbool; cdecl;
+function SDL_SetTLS(id: PSDL_TLSID; value: Pointer; destructor_: TSDL_TLSDestructorCallback): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTLS' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_time.inc
+++ b/units/SDL_time.inc
@@ -88,7 +88,7 @@ const
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GetDateTimeLocalePreferences(dateFormat: PSDL_DateFormat; timeFormat: PSDL_TimeFormat): cbool; cdecl;
+function SDL_GetDateTimeLocalePreferences(dateFormat: PSDL_DateFormat; timeFormat: PSDL_TimeFormat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetDateTimeLocalePreferences' {$ENDIF} {$ENDIF};
 
 {*
@@ -101,7 +101,7 @@ function SDL_GetDateTimeLocalePreferences(dateFormat: PSDL_DateFormat; timeForma
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_GetCurrentTime(ticks: PSDL_Time): cbool; cdecl;
+function SDL_GetCurrentTime(ticks: PSDL_Time): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetCurrentTime' {$ENDIF} {$ENDIF};
 
 {*
@@ -118,7 +118,7 @@ function SDL_GetCurrentTime(ticks: PSDL_Time): cbool; cdecl;
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_TimeToDateTime(ticks: TSDL_Time; dt: PSDL_DateTime; localTime: cbool): cbool; cdecl;
+function SDL_TimeToDateTime(ticks: TSDL_Time; dt: PSDL_DateTime; localTime: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_TimeToDateTime' {$ENDIF} {$ENDIF};
 
 {*
@@ -134,7 +134,7 @@ function SDL_TimeToDateTime(ticks: TSDL_Time; dt: PSDL_DateTime; localTime: cboo
  *
  * \since This function is available since SDL 3.2.0.
   }
-function SDL_DateTimeToTime(dt: PSDL_DateTime; ticks: PSDL_Time): cbool; cdecl;
+function SDL_DateTimeToTime(dt: PSDL_DateTime; ticks: PSDL_Time): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_DateTimeToTime' {$ENDIF} {$ENDIF};
 
 {*

--- a/units/SDL_timer.inc
+++ b/units/SDL_timer.inc
@@ -286,6 +286,6 @@ function SDL_AddTimerNS(interval: cuint64; callback: TSDL_NSTimerCallback; userd
  *
  * \sa SDL_AddTimer
   }
-function SDL_RemoveTimer(id: TSDL_TimerID): cbool; cdecl;
+function SDL_RemoveTimer(id: TSDL_TimerID): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RemoveTimer' {$ENDIF} {$ENDIF};
 

--- a/units/SDL_tray.inc
+++ b/units/SDL_tray.inc
@@ -355,7 +355,7 @@ function SDL_GetTrayEntryLabel(entry: PSDL_TrayEntry): PAnsiChar; cdecl;
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_GetTrayEntryChecked
  *}
-procedure SDL_SetTrayEntryChecked(entry: PSDL_TrayEntry; checked: cbool); cdecl;
+procedure SDL_SetTrayEntryChecked(entry: PSDL_TrayEntry; checked: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTrayEntryChecked' {$ENDIF} {$ENDIF};
 
 {**
@@ -375,7 +375,7 @@ procedure SDL_SetTrayEntryChecked(entry: PSDL_TrayEntry; checked: cbool); cdecl;
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_SetTrayEntryChecked
  *}
-function SDL_GetTrayEntryChecked(entry: PSDL_TrayEntry): cbool; cdecl;
+function SDL_GetTrayEntryChecked(entry: PSDL_TrayEntry): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTrayEntryChecked' {$ENDIF} {$ENDIF};
 
 {**
@@ -393,7 +393,7 @@ function SDL_GetTrayEntryChecked(entry: PSDL_TrayEntry): cbool; cdecl;
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_GetTrayEntryEnabled
  *}
-procedure SDL_SetTrayEntryEnabled(entry: PSDL_TrayEntry; enabled: cbool); cdecl;
+procedure SDL_SetTrayEntryEnabled(entry: PSDL_TrayEntry; enabled: Boolean); cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetTrayEntryEnabled' {$ENDIF} {$ENDIF};
 
 {**
@@ -411,7 +411,7 @@ procedure SDL_SetTrayEntryEnabled(entry: PSDL_TrayEntry; enabled: cbool); cdecl;
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_SetTrayEntryEnabled
  *}
-function SDL_GetTrayEntryEnabled(entry: PSDL_TrayEntry): cbool; cdecl;
+function SDL_GetTrayEntryEnabled(entry: PSDL_TrayEntry): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetTrayEntryEnabled' {$ENDIF} {$ENDIF};
 
 {**

--- a/units/SDL_video.inc
+++ b/units/SDL_video.inc
@@ -583,7 +583,7 @@ function SDL_GetDisplayName(displayID: TSDL_DisplayID): PAnsiChar; cdecl;
  * \sa SDL_GetDisplayUsableBounds
  * \sa SDL_GetDisplays
   }
-function SDL_GetDisplayBounds(displayID: TSDL_DisplayID; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetDisplayBounds(displayID: TSDL_DisplayID; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetDisplayBounds' {$ENDIF} {$ENDIF};
 
 {*
@@ -608,7 +608,7 @@ function SDL_GetDisplayBounds(displayID: TSDL_DisplayID; rect: PSDL_Rect): cbool
  * \sa SDL_GetDisplayBounds
  * \sa SDL_GetDisplays
   }
-function SDL_GetDisplayUsableBounds(displayID: TSDL_DisplayID; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetDisplayUsableBounds(displayID: TSDL_DisplayID; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetDisplayUsableBounds' {$ENDIF} {$ENDIF};
 
 {*
@@ -712,7 +712,7 @@ function SDL_GetFullscreenDisplayModes(displayID: TSDL_DisplayID; count: pcint):
  * \sa SDL_GetDisplays
  * \sa SDL_GetFullscreenDisplayModes
   }
-function SDL_GetClosestFullscreenDisplayMode(displayID: TSDL_DisplayID; w: cint; h: cint; refresh_rate: cfloat; include_high_density_modes: cbool; mode: PSDL_DisplayMode): cbool; cdecl;
+function SDL_GetClosestFullscreenDisplayMode(displayID: TSDL_DisplayID; w: cint; h: cint; refresh_rate: cfloat; include_high_density_modes: Boolean; mode: PSDL_DisplayMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetClosestFullscreenDisplayMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -874,7 +874,7 @@ function SDL_GetWindowDisplayScale(window: PSDL_Window): cfloat; cdecl;
  * \sa SDL_SetWindowFullscreen
  * \sa SDL_SyncWindow
   }
-function SDL_SetWindowFullscreenMode(window: PSDL_Window; mode: PSDL_DisplayMode): cbool; cdecl;
+function SDL_SetWindowFullscreenMode(window: PSDL_Window; mode: PSDL_DisplayMode): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowFullscreenMode' {$ENDIF} {$ENDIF};
 
 {*
@@ -1471,7 +1471,7 @@ function SDL_GetWindowFlags(window: PSDL_Window): TSDL_WindowFlags; cdecl;
  *
  * \sa SDL_GetWindowTitle
   }
-function SDL_SetWindowTitle(window: PSDL_Window; title: PAnsiChar): cbool; cdecl;
+function SDL_SetWindowTitle(window: PSDL_Window; title: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowTitle' {$ENDIF} {$ENDIF};
 
 {*
@@ -1508,7 +1508,7 @@ function SDL_GetWindowTitle(window: PSDL_Window): PAnsiChar; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetWindowIcon(window: PSDL_Window; icon: PSDL_Surface): cbool; cdecl;
+function SDL_SetWindowIcon(window: PSDL_Window; icon: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowIcon' {$ENDIF} {$ENDIF};
 
 {*
@@ -1549,7 +1549,7 @@ function SDL_SetWindowIcon(window: PSDL_Window; icon: PSDL_Surface): cbool; cdec
  * \sa SDL_GetWindowPosition
  * \sa SDL_SyncWindow
   }
-function SDL_SetWindowPosition(window: PSDL_Window; x: cint; y: cint): cbool; cdecl;
+function SDL_SetWindowPosition(window: PSDL_Window; x: cint; y: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowPosition' {$ENDIF} {$ENDIF};
 
 {*
@@ -1573,7 +1573,7 @@ function SDL_SetWindowPosition(window: PSDL_Window; x: cint; y: cint): cbool; cd
  *
  * \sa SDL_SetWindowPosition
   }
-function SDL_GetWindowPosition(window: PSDL_Window; x: pcint; y: pcint): cbool; cdecl;
+function SDL_GetWindowPosition(window: PSDL_Window; x: pcint; y: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowPosition' {$ENDIF} {$ENDIF};
 
 {*
@@ -1610,7 +1610,7 @@ function SDL_GetWindowPosition(window: PSDL_Window; x: pcint; y: pcint): cbool; 
  * \sa SDL_SetWindowFullscreenMode
  * \sa SDL_SyncWindow
   }
-function SDL_SetWindowSize(window: PSDL_Window; w: cint; h: cint): cbool; cdecl;
+function SDL_SetWindowSize(window: PSDL_Window; w: cint; h: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1632,7 +1632,7 @@ function SDL_SetWindowSize(window: PSDL_Window; w: cint; h: cint): cbool; cdecl;
  * \sa SDL_GetWindowSizeInPixels
  * \sa SDL_SetWindowSize
   }
-function SDL_GetWindowSize(window: PSDL_Window; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetWindowSize(window: PSDL_Window; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1653,7 +1653,7 @@ function SDL_GetWindowSize(window: PSDL_Window; w: pcint; h: pcint): cbool; cdec
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GetWindowSafeArea(window: PSDL_Window; rect: PSDL_Rect): cbool; cdecl;
+function SDL_GetWindowSafeArea(window: PSDL_Window; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowSafeArea' {$ENDIF} {$ENDIF};
 
 {*
@@ -1693,7 +1693,7 @@ function SDL_GetWindowSafeArea(window: PSDL_Window; rect: PSDL_Rect): cbool; cde
  * \sa SDL_GetWindowAspectRatio
  * \sa SDL_SyncWindow
   }
-function SDL_SetWindowAspectRatio(window: PSDL_Window; min_aspect: cfloat; max_aspect: cfloat): cbool; cdecl;
+function SDL_SetWindowAspectRatio(window: PSDL_Window; min_aspect: cfloat; max_aspect: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowAspectRatio' {$ENDIF} {$ENDIF};
 
 {*
@@ -1711,7 +1711,7 @@ function SDL_SetWindowAspectRatio(window: PSDL_Window; min_aspect: cfloat; max_a
  *
  * \sa SDL_SetWindowAspectRatio
   }
-function SDL_GetWindowAspectRatio(window: PSDL_Window; min_aspect: pcfloat; max_aspect: pcfloat): cbool; cdecl;
+function SDL_GetWindowAspectRatio(window: PSDL_Window; min_aspect: pcfloat; max_aspect: pcfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowAspectRatio' {$ENDIF} {$ENDIF};
 
 {*
@@ -1747,7 +1747,7 @@ function SDL_GetWindowAspectRatio(window: PSDL_Window; min_aspect: pcfloat; max_
  *
  * \sa SDL_GetWindowSize
   }
-function SDL_GetWindowBordersSize(window: PSDL_Window; top: pcint; left: pcint; bottom: pcint; right: pcint): cbool; cdecl;
+function SDL_GetWindowBordersSize(window: PSDL_Window; top: pcint; left: pcint; bottom: pcint; right: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowBordersSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1766,7 +1766,7 @@ function SDL_GetWindowBordersSize(window: PSDL_Window; top: pcint; left: pcint; 
  * \sa SDL_CreateWindow
  * \sa SDL_GetWindowSize
   }
-function SDL_GetWindowSizeInPixels(window: PSDL_Window; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetWindowSizeInPixels(window: PSDL_Window; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowSizeInPixels' {$ENDIF} {$ENDIF};
 
 {*
@@ -1783,7 +1783,7 @@ function SDL_GetWindowSizeInPixels(window: PSDL_Window; w: pcint; h: pcint): cbo
  * \sa SDL_GetWindowMinimumSize
  * \sa SDL_SetWindowMaximumSize
   }
-function SDL_SetWindowMinimumSize(window: PSDL_Window; min_w: cint; min_h: cint): cbool; cdecl;
+function SDL_SetWindowMinimumSize(window: PSDL_Window; min_w: cint; min_h: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowMinimumSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1802,7 +1802,7 @@ function SDL_SetWindowMinimumSize(window: PSDL_Window; min_w: cint; min_h: cint)
  * \sa SDL_GetWindowMaximumSize
  * \sa SDL_SetWindowMinimumSize
   }
-function SDL_GetWindowMinimumSize(window: PSDL_Window; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetWindowMinimumSize(window: PSDL_Window; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowMinimumSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1819,7 +1819,7 @@ function SDL_GetWindowMinimumSize(window: PSDL_Window; w: pcint; h: pcint): cboo
  * \sa SDL_GetWindowMaximumSize
  * \sa SDL_SetWindowMinimumSize
   }
-function SDL_SetWindowMaximumSize(window: PSDL_Window; max_w: cint; max_h: cint): cbool; cdecl;
+function SDL_SetWindowMaximumSize(window: PSDL_Window; max_w: cint; max_h: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowMaximumSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1838,7 +1838,7 @@ function SDL_SetWindowMaximumSize(window: PSDL_Window; max_w: cint; max_h: cint)
  * \sa SDL_GetWindowMinimumSize
  * \sa SDL_SetWindowMaximumSize
   }
-function SDL_GetWindowMaximumSize(window: PSDL_Window; w: pcint; h: pcint): cbool; cdecl;
+function SDL_GetWindowMaximumSize(window: PSDL_Window; w: pcint; h: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowMaximumSize' {$ENDIF} {$ENDIF};
 
 {*
@@ -1859,7 +1859,7 @@ function SDL_GetWindowMaximumSize(window: PSDL_Window; w: pcint; h: pcint): cboo
  *
  * \sa SDL_GetWindowFlags
   }
-function SDL_SetWindowBordered(window: PSDL_Window; bordered: cbool): cbool; cdecl;
+function SDL_SetWindowBordered(window: PSDL_Window; bordered: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowBordered' {$ENDIF} {$ENDIF};
 
 {*
@@ -1880,7 +1880,7 @@ function SDL_SetWindowBordered(window: PSDL_Window; bordered: cbool): cbool; cde
  *
  * \sa SDL_GetWindowFlags
   }
-function SDL_SetWindowResizable(window: PSDL_Window; resizable: cbool): cbool; cdecl;
+function SDL_SetWindowResizable(window: PSDL_Window; resizable: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowResizable' {$ENDIF} {$ENDIF};
 
 {*
@@ -1898,7 +1898,7 @@ function SDL_SetWindowResizable(window: PSDL_Window; resizable: cbool): cbool; c
  *
  * \sa SDL_GetWindowFlags
   }
-function SDL_SetWindowAlwaysOnTop(window: PSDL_Window; on_top: cbool): cbool; cdecl;
+function SDL_SetWindowAlwaysOnTop(window: PSDL_Window; on_top: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowAlwaysOnTop' {$ENDIF} {$ENDIF};
 
 {*
@@ -1913,7 +1913,7 @@ function SDL_SetWindowAlwaysOnTop(window: PSDL_Window; on_top: cbool): cbool; cd
  * \sa SDL_HideWindow
  * \sa SDL_RaiseWindow
   }
-function SDL_ShowWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_ShowWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -1927,7 +1927,7 @@ function SDL_ShowWindow(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_ShowWindow
   }
-function SDL_HideWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_HideWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HideWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -1946,7 +1946,7 @@ function SDL_HideWindow(window: PSDL_Window): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_RaiseWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_RaiseWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RaiseWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -1979,7 +1979,7 @@ function SDL_RaiseWindow(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_RestoreWindow
  * \sa SDL_SyncWindow
   }
-function SDL_MaximizeWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_MaximizeWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_MaximizeWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -2004,7 +2004,7 @@ function SDL_MaximizeWindow(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_RestoreWindow
  * \sa SDL_SyncWindow
   }
-function SDL_MinimizeWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_MinimizeWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_MinimizeWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -2030,7 +2030,7 @@ function SDL_MinimizeWindow(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_MinimizeWindow
  * \sa SDL_SyncWindow
   }
-function SDL_RestoreWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_RestoreWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RestoreWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -2060,7 +2060,7 @@ function SDL_RestoreWindow(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_SetWindowFullscreenMode
  * \sa SDL_SyncWindow
   }
-function SDL_SetWindowFullscreen(window: PSDL_Window; fullscreen: cbool): cbool; cdecl;
+function SDL_SetWindowFullscreen(window: PSDL_Window; fullscreen: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowFullscreen' {$ENDIF} {$ENDIF};
 
 {*
@@ -2090,7 +2090,7 @@ function SDL_SetWindowFullscreen(window: PSDL_Window; fullscreen: cbool): cbool;
  * \sa SDL_RestoreWindow
  * \sa SDL_HINT_VIDEO_SYNC_WINDOW_OPERATIONS
   }
-function SDL_SyncWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_SyncWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SyncWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -2104,7 +2104,7 @@ function SDL_SyncWindow(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_GetWindowSurface
   }
-function SDL_WindowHasSurface(window: PSDL_Window): cbool; cdecl;
+function SDL_WindowHasSurface(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WindowHasSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -2157,7 +2157,7 @@ function SDL_GetWindowSurface(window: PSDL_Window): PSDL_Surface; cdecl;
  *
  * \sa SDL_GetWindowSurfaceVSync
   }
-function SDL_SetWindowSurfaceVSync(window: PSDL_Window; vsync: cint): cbool; cdecl;
+function SDL_SetWindowSurfaceVSync(window: PSDL_Window; vsync: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowSurfaceVSync' {$ENDIF} {$ENDIF};
 
   const
@@ -2177,7 +2177,7 @@ function SDL_SetWindowSurfaceVSync(window: PSDL_Window; vsync: cint): cbool; cde
  *
  * \sa SDL_SetWindowSurfaceVSync
   }
-function SDL_GetWindowSurfaceVSync(window: PSDL_Window; vsync: pcint): cbool; cdecl;
+function SDL_GetWindowSurfaceVSync(window: PSDL_Window; vsync: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowSurfaceVSync' {$ENDIF} {$ENDIF};
 
 {*
@@ -2197,7 +2197,7 @@ function SDL_GetWindowSurfaceVSync(window: PSDL_Window; vsync: pcint): cbool; cd
  * \sa SDL_GetWindowSurface
  * \sa SDL_UpdateWindowSurfaceRects
   }
-function SDL_UpdateWindowSurface(window: PSDL_Window): cbool; cdecl;
+function SDL_UpdateWindowSurface(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateWindowSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -2225,7 +2225,7 @@ function SDL_UpdateWindowSurface(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_GetWindowSurface
  * \sa SDL_UpdateWindowSurface
   }
-function SDL_UpdateWindowSurfaceRects(window: PSDL_Window; rects: PSDL_Rect; numrects: cint): cbool; cdecl;
+function SDL_UpdateWindowSurfaceRects(window: PSDL_Window; rects: PSDL_Rect; numrects: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_UpdateWindowSurfaceRects' {$ENDIF} {$ENDIF};
 
 {*
@@ -2240,7 +2240,7 @@ function SDL_UpdateWindowSurfaceRects(window: PSDL_Window; rects: PSDL_Rect; num
  * \sa SDL_GetWindowSurface
  * \sa SDL_WindowHasSurface
   }
-function SDL_DestroyWindowSurface(window: PSDL_Window): cbool; cdecl;
+function SDL_DestroyWindowSurface(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_DestroyWindowSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -2272,7 +2272,7 @@ function SDL_DestroyWindowSurface(window: PSDL_Window): cbool; cdecl;
  * \sa SDL_GetWindowKeyboardGrab
  * \sa SDL_SetWindowMouseGrab
   }
-function SDL_SetWindowKeyboardGrab(window: PSDL_Window; grabbed: cbool): cbool; cdecl;
+function SDL_SetWindowKeyboardGrab(window: PSDL_Window; grabbed: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowKeyboardGrab' {$ENDIF} {$ENDIF};
 
 {*
@@ -2290,7 +2290,7 @@ function SDL_SetWindowKeyboardGrab(window: PSDL_Window; grabbed: cbool): cbool; 
  * \sa SDL_GetWindowMouseGrab
  * \sa SDL_SetWindowKeyboardGrab
   }
-function SDL_SetWindowMouseGrab(window: PSDL_Window; grabbed: cbool): cbool; cdecl;
+function SDL_SetWindowMouseGrab(window: PSDL_Window; grabbed: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowMouseGrab' {$ENDIF} {$ENDIF};
 
 {*
@@ -2303,7 +2303,7 @@ function SDL_SetWindowMouseGrab(window: PSDL_Window; grabbed: cbool): cbool; cde
  *
  * \sa SDL_SetWindowKeyboardGrab
   }
-function SDL_GetWindowKeyboardGrab(window: PSDL_Window): cbool; cdecl;
+function SDL_GetWindowKeyboardGrab(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowKeyboardGrab' {$ENDIF} {$ENDIF};
 
 {*
@@ -2316,7 +2316,7 @@ function SDL_GetWindowKeyboardGrab(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_SetWindowKeyboardGrab
   }
-function SDL_GetWindowMouseGrab(window: PSDL_Window): cbool; cdecl;
+function SDL_GetWindowMouseGrab(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowMouseGrab' {$ENDIF} {$ENDIF};
 
 {*
@@ -2349,7 +2349,7 @@ function SDL_GetGrabbedWindow: PSDL_Window; cdecl;
  * \sa SDL_GetWindowMouseRect
  * \sa SDL_SetWindowMouseGrab
   }
-function SDL_SetWindowMouseRect(window: PSDL_Window; rect: PSDL_Rect): cbool; cdecl;
+function SDL_SetWindowMouseRect(window: PSDL_Window; rect: PSDL_Rect): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowMouseRect' {$ENDIF} {$ENDIF};
 
 {*
@@ -2383,7 +2383,7 @@ function SDL_GetWindowMouseRect(window: PSDL_Window): PSDL_Rect; cdecl;
  *
  * \sa SDL_GetWindowOpacity
   }
-function SDL_SetWindowOpacity(window: PSDL_Window; opacity: cfloat): cbool; cdecl;
+function SDL_SetWindowOpacity(window: PSDL_Window; opacity: cfloat): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowOpacity' {$ENDIF} {$ENDIF};
 
 {*
@@ -2433,7 +2433,7 @@ function SDL_GetWindowOpacity(window: PSDL_Window): cfloat; cdecl;
  *
  * \sa SDL_SetWindowModal
   }
-function SDL_SetWindowParent(window: PSDL_Window; parent: PSDL_Window): cbool; cdecl;
+function SDL_SetWindowParent(window: PSDL_Window; parent: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowParent' {$ENDIF} {$ENDIF};
 
 {*
@@ -2451,7 +2451,7 @@ function SDL_SetWindowParent(window: PSDL_Window; parent: PSDL_Window): cbool; c
  *
  * \sa SDL_SetWindowParent
   }
-function SDL_SetWindowModal(window: PSDL_Window; modal: cbool): cbool; cdecl;
+function SDL_SetWindowModal(window: PSDL_Window; modal: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowModal' {$ENDIF} {$ENDIF};
 
 {*
@@ -2464,7 +2464,7 @@ function SDL_SetWindowModal(window: PSDL_Window; modal: cbool): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetWindowFocusable(window: PSDL_Window; focusable: cbool): cbool; cdecl;
+function SDL_SetWindowFocusable(window: PSDL_Window; focusable: Boolean): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowFocusable' {$ENDIF} {$ENDIF};
 
 {*
@@ -2488,7 +2488,7 @@ function SDL_SetWindowFocusable(window: PSDL_Window; focusable: cbool): cbool; c
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_ShowWindowSystemMenu(window: PSDL_Window; x: cint; y: cint): cbool; cdecl;
+function SDL_ShowWindowSystemMenu(window: PSDL_Window; x: cint; y: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ShowWindowSystemMenu' {$ENDIF} {$ENDIF};
 
 {*
@@ -2567,7 +2567,7 @@ type
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetWindowHitTest(window: PSDL_Window; callback: TSDL_HitTest; callback_data: Pointer): cbool; cdecl;
+function SDL_SetWindowHitTest(window: PSDL_Window; callback: TSDL_HitTest; callback_data: Pointer): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowHitTest' {$ENDIF} {$ENDIF};
 
 {*
@@ -2594,7 +2594,7 @@ function SDL_SetWindowHitTest(window: PSDL_Window; callback: TSDL_HitTest; callb
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_SetWindowShape(window: PSDL_Window; shape: PSDL_Surface): cbool; cdecl;
+function SDL_SetWindowShape(window: PSDL_Window; shape: PSDL_Surface): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowShape' {$ENDIF} {$ENDIF};
 
 {*
@@ -2607,7 +2607,7 @@ function SDL_SetWindowShape(window: PSDL_Window; shape: PSDL_Surface): cbool; cd
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_FlashWindow(window: PSDL_Window; operation: TSDL_FlashOperation): cbool; cdecl;
+function SDL_FlashWindow(window: PSDL_Window; operation: TSDL_FlashOperation): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_FlashWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -2641,7 +2641,7 @@ procedure SDL_DestroyWindow(window: PSDL_Window); cdecl;
  * \sa SDL_DisableScreenSaver
  * \sa SDL_EnableScreenSaver
   }
-function SDL_ScreenSaverEnabled: cbool; cdecl;
+function SDL_ScreenSaverEnabled: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ScreenSaverEnabled' {$ENDIF} {$ENDIF};
 
 {*
@@ -2655,7 +2655,7 @@ function SDL_ScreenSaverEnabled: cbool; cdecl;
  * \sa SDL_DisableScreenSaver
  * \sa SDL_ScreenSaverEnabled
   }
-function SDL_EnableScreenSaver: cbool; cdecl;
+function SDL_EnableScreenSaver: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_EnableScreenSaver' {$ENDIF} {$ENDIF};
 
 {*
@@ -2675,7 +2675,7 @@ function SDL_EnableScreenSaver: cbool; cdecl;
  * \sa SDL_EnableScreenSaver
  * \sa SDL_ScreenSaverEnabled
   }
-function SDL_DisableScreenSaver: cbool; cdecl;
+function SDL_DisableScreenSaver: Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_DisableScreenSaver' {$ENDIF} {$ENDIF};
 
 {*
@@ -2702,7 +2702,7 @@ function SDL_DisableScreenSaver: cbool; cdecl;
  * \sa SDL_GL_GetProcAddress
  * \sa SDL_GL_UnloadLibrary
   }
-function SDL_GL_LoadLibrary(path: PAnsiChar): cbool; cdecl;
+function SDL_GL_LoadLibrary(path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_LoadLibrary' {$ENDIF} {$ENDIF};
 
 {*
@@ -2806,7 +2806,7 @@ procedure SDL_GL_UnloadLibrary; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GL_ExtensionSupported(extension: PAnsiChar): cbool; cdecl;
+function SDL_GL_ExtensionSupported(extension: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_ExtensionSupported' {$ENDIF} {$ENDIF};
 
 {*
@@ -2839,7 +2839,7 @@ procedure SDL_GL_ResetAttributes; cdecl;
  * \sa SDL_GL_GetAttribute
  * \sa SDL_GL_ResetAttributes
   }
-function SDL_GL_SetAttribute(attr: TSDL_GLAttr; value: cint): cbool; cdecl;
+function SDL_GL_SetAttribute(attr: TSDL_GLAttr; value: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_SetAttribute' {$ENDIF} {$ENDIF};
 
 {*
@@ -2856,7 +2856,7 @@ function SDL_GL_SetAttribute(attr: TSDL_GLAttr; value: cint): cbool; cdecl;
  * \sa SDL_GL_ResetAttributes
  * \sa SDL_GL_SetAttribute
   }
-function SDL_GL_GetAttribute(attr: TSDL_GLAttr; value: pcint): cbool; cdecl;
+function SDL_GL_GetAttribute(attr: TSDL_GLAttr; value: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_GetAttribute' {$ENDIF} {$ENDIF};
 
 {*
@@ -2896,7 +2896,7 @@ function SDL_GL_CreateContext(window: PSDL_Window): TSDL_GLContext; cdecl;
  *
  * \sa SDL_GL_CreateContext
   }
-function SDL_GL_MakeCurrent(window: PSDL_Window; context: TSDL_GLContext): cbool; cdecl;
+function SDL_GL_MakeCurrent(window: PSDL_Window; context: TSDL_GLContext): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_MakeCurrent' {$ENDIF} {$ENDIF};
 
 {*
@@ -3005,7 +3005,7 @@ procedure SDL_EGL_SetAttributeCallbacks(platformAttribCallback: TSDL_EGLAttribAr
  *
  * \sa SDL_GL_GetSwapInterval
   }
-function SDL_GL_SetSwapInterval(interval: cint): cbool; cdecl;
+function SDL_GL_SetSwapInterval(interval: cint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_SetSwapInterval' {$ENDIF} {$ENDIF};
 
 {*
@@ -3025,7 +3025,7 @@ function SDL_GL_SetSwapInterval(interval: cint): cbool; cdecl;
  *
  * \sa SDL_GL_SetSwapInterval
   }
-function SDL_GL_GetSwapInterval(interval: pcint): cbool; cdecl;
+function SDL_GL_GetSwapInterval(interval: pcint): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_GetSwapInterval' {$ENDIF} {$ENDIF};
 
 {*
@@ -3044,7 +3044,7 @@ function SDL_GL_GetSwapInterval(interval: pcint): cbool; cdecl;
  *
  * \since This function is available since SDL 3.1.3.
   }
-function SDL_GL_SwapWindow(window: PSDL_Window): cbool; cdecl;
+function SDL_GL_SwapWindow(window: PSDL_Window): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_SwapWindow' {$ENDIF} {$ENDIF};
 
 {*
@@ -3058,5 +3058,5 @@ function SDL_GL_SwapWindow(window: PSDL_Window): cbool; cdecl;
  *
  * \sa SDL_GL_CreateContext
   }
-function SDL_GL_DestroyContext(context: TSDL_GLContext): cbool; cdecl;
+function SDL_GL_DestroyContext(context: TSDL_GLContext): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GL_DestroyContext' {$ENDIF} {$ENDIF};

--- a/units/SDL_vulkan.inc
+++ b/units/SDL_vulkan.inc
@@ -125,7 +125,7 @@ type
  * \sa SDL_Vulkan_GetVkGetInstanceProcAddr
  * \sa SDL_Vulkan_UnloadLibrary
   }
-function SDL_Vulkan_LoadLibrary(path: PAnsiChar): cbool; cdecl;
+function SDL_Vulkan_LoadLibrary(path: PAnsiChar): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_Vulkan_LoadLibrary' {$ENDIF} {$ENDIF};
 
 {*
@@ -222,7 +222,7 @@ function SDL_Vulkan_GetInstanceExtensions(count: pcuint32):PPAnsiChar; cdecl;
  * \sa SDL_Vulkan_GetInstanceExtensions
  * \sa SDL_Vulkan_DestroySurface
   }
-function SDL_Vulkan_CreateSurface(window: PSDL_Window; instance: TVkInstance; allocator: PVkAllocationCallbacks; surface: PVkSurfaceKHR): cbool; cdecl;
+function SDL_Vulkan_CreateSurface(window: PSDL_Window; instance: TVkInstance; allocator: PVkAllocationCallbacks; surface: PVkSurfaceKHR): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_Vulkan_CreateSurface' {$ENDIF} {$ENDIF};
 
 {*
@@ -268,5 +268,5 @@ procedure SDL_Vulkan_DestroySurface(instance: TVkInstance; surface: TVkSurfaceKH
  *
  * \sa SDL_Vulkan_GetInstanceExtensions
   }
-function SDL_Vulkan_GetPresentationSupport(instance: TVkInstance; physicalDevice: TVkPhysicalDevice; queueFamilyIndex: cuint32): cbool; cdecl;
+function SDL_Vulkan_GetPresentationSupport(instance: TVkInstance; physicalDevice: TVkPhysicalDevice; queueFamilyIndex: cuint32): Boolean; cdecl;
   external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_Vulkan_GetPresentationSupport' {$ENDIF} {$ENDIF};

--- a/units/ctypes.inc
+++ b/units/ctypes.inc
@@ -24,11 +24,6 @@
 type
   DWord = LongWord;
 
-  ppcbool = ^pcbool;
-  pcbool = ^cbool;
-  cbool = LongBool;
-  {$EXTERNALSYM cbool}
-
   ppcint8 = ^pcint8;
   pcint8 = ^cint8;
   cint8 = ShortInt;


### PR DESCRIPTION
Per discussion in #26, this PR replaces all occurrences of `cbool` with `Boolean` to fix struct size mismatch between C headers and our Pascal units.