### PR TITLE
Translate pixel format and colorspace macros

### DIFF
--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -360,5 +360,11 @@ begin
   SDL_CreateThreadWithProperties:=SDL_CreateThreadWithPropertiesRuntime(props,TSDL_FunctionPointer(SDL_BeginThreadFunction),TSDL_FunctionPointer(SDL_EndThreadFunction));
 end;
 
+{ Macros from SDL_mouse.h }
+function SDL_BUTTON_MASK(X: TSDL_MouseButtonFlags): TSDL_MouseButtonFlags;
+begin
+  Result := TSDL_MouseButtonFlags(1) shl (X-1)
+end;
+
 end.
 

--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -372,4 +372,132 @@ begin
   Result := (cuint32(Ord(A)) shl 0) or (cuint32(Ord(B)) shl 8) or (cuint32(Ord(C)) shl 16) or (cuint32(Ord(D)) shl 24)
 end;
 
+{ Macros from SDL_pixels.h }
+function SDL_DEFINE_PIXELFOURCC(A, B, C, D: AnsiChar): TSDL_PixelFormat;
+begin
+  Result := SDL_FOURCC(A, B, C, D)
+end;
+
+function SDL_DEFINE_PIXELFORMAT(type_: TSDL_PixelType; order: Integer; layout: TSDL_PackedLayout; bits, bytes: Integer): TSDL_PixelFormat;
+begin
+  Result := (1 shl 28) or (type_ shl 24) or (order shl 20) or (layout shl 16) or (bits shl 8) or (bytes shl 0)
+end;
+
+function SDL_PIXELFLAG(format: TSDL_PixelFormat): Integer;
+begin
+  Result := (format shr 28) and $0F
+end;
+
+function SDL_PIXELTYPE(format: TSDL_PixelFormat): TSDL_PixelType;
+begin
+  Result := (format shr 24) and $0F
+end;
+
+function SDL_PIXELORDER(format: TSDL_PixelFormat): Integer;
+begin
+  Result := (format shr 20) and $0F
+end;
+
+function SDL_PIXELLAYOUT(format: TSDL_PixelFormat): TSDL_PackedLayout;
+begin
+  Result := (format shr 16) and $0F
+end;
+
+function SDL_BITSPERPIXEL(format: TSDL_PixelFormat): Integer;
+begin
+  If SDL_ISPIXELFORMAT_FOURCC(format) then
+    Result := 0
+  else
+    Result := (format shr 8) and $0F
+end;
+
+function SDL_BYTESPERPIXEL(format: TSDL_PixelFormat): Integer;
+begin
+  If SDL_ISPIXELFORMAT_FOURCC(format) then
+    If (format = SDL_PIXELFORMAT_YUY2) or (format = SDL_PIXELFORMAT_UYVY) or (format = SDL_PIXELFORMAT_YVYU) or (format = SDL_PIXELFORMAT_P010) then
+      Result := 2
+    else
+      Result := 1
+  else
+    Result := (format shr 0) and $0F
+end;
+
+function SDL_ISPIXELFORMAT_INDEXED(format: TSDL_PixelFormat): Boolean;
+begin
+  Result := (Not SDL_ISPIXELFORMAT_FOURCC(format)) and
+    (
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_INDEX1) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_INDEX2) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_INDEX4) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_INDEX8)
+    )
+end;
+
+function SDL_ISPIXELFORMAT_PACKED(format: TSDL_PixelFormat): Boolean;
+begin
+  Result := (Not SDL_ISPIXELFORMAT_FOURCC(format)) and
+    (
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_PACKED8) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_PACKED16) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_PACKED32)
+    )
+end;
+
+function SDL_ISPIXELFORMAT_ARRAY(format: TSDL_PixelFormat): Boolean;
+begin
+  Result := (Not SDL_ISPIXELFORMAT_FOURCC(format)) and
+    (
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYU8) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYU16) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYU32) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYF16) or
+      (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYF32)
+    )
+end;
+
+function SDL_ISPIXELFORMAT_10BIT(format: TSDL_PixelFormat): Boolean;
+begin
+  Result := (Not SDL_ISPIXELFORMAT_FOURCC(format)) and
+    (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_PACKED32) and
+    (SDL_PIXELLAYOUT(format) = SDL_PACKEDLAYOUT_2101010)
+end;
+
+function SDL_ISPIXELFORMAT_FLOAT(format: TSDL_PixelFormat): Boolean;
+begin
+  Result := (Not SDL_ISPIXELFORMAT_FOURCC(format)) and
+    ((SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYF16) or (SDL_PIXELTYPE(format) = SDL_PIXELTYPE_ARRAYF32))
+end;
+
+function SDL_ISPIXELFORMAT_ALPHA(format: TSDL_PixelFormat): Boolean;
+begin
+  Result :=
+    (
+      (
+        SDL_ISPIXELFORMAT_PACKED(format) and
+        (
+          (SDL_PIXELORDER(format) = SDL_PACKEDORDER_ARGB) or
+          (SDL_PIXELORDER(format) = SDL_PACKEDORDER_RGBA) or
+          (SDL_PIXELORDER(format) = SDL_PACKEDORDER_ABGR) or
+          (SDL_PIXELORDER(format) = SDL_PACKEDORDER_BGRA)
+        )
+      )
+      or
+      (
+        SDL_ISPIXELFORMAT_ARRAY(format) and
+        (
+          (SDL_PIXELORDER(format) = SDL_ARRAYORDER_ARGB) or
+          (SDL_PIXELORDER(format) = SDL_ARRAYORDER_RGBA) or
+          (SDL_PIXELORDER(format) = SDL_ARRAYORDER_ABGR) or
+          (SDL_PIXELORDER(format) = SDL_ARRAYORDER_BGRA)
+        )
+      )
+    )
+end;
+
+function SDL_ISPIXELFORMAT_FOURCC(format: TSDL_PixelFormat): Boolean;
+begin
+  (* The flag is set to 1 because 0x1? is not in the printable ASCII range *)
+  Result := (format <> 0) and (SDL_PIXELFLAG(format) <> 1)
+end;
+
 end.

--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -366,5 +366,10 @@ begin
   Result := TSDL_MouseButtonFlags(1) shl (X-1)
 end;
 
-end.
+{ Macros from SDL_stdinc.h}
+function SDL_FOURCC(A, B, C, D: AnsiChar): cuint32;
+begin
+  Result := (cuint32(Ord(A)) shl 0) or (cuint32(Ord(B)) shl 8) or (cuint32(Ord(C)) shl 16) or (cuint32(Ord(D)) shl 24)
+end;
 
+end.

--- a/units/SDL3.pas
+++ b/units/SDL3.pas
@@ -500,4 +500,72 @@ begin
   Result := (format <> 0) and (SDL_PIXELFLAG(format) <> 1)
 end;
 
+function SDL_DEFINE_COLORSPACE(
+  type_: TSDL_ColorType;
+  range: TSDL_ColorRange;
+  primaries: TSDL_ColorPrimaries;
+  transfer: TSDL_TransferCharacteristics;
+  matrix: TSDL_MatrixCoefficients;
+  chroma: TSDL_ChromaLocation
+): TSDL_Colorspace;
+begin
+  Result := (cuint32(type_) shl 28) or (cuint32(range) shl 24) or (cuint32(chroma) shl 20) or
+    (cuint32(primaries) shl 10) or (cuint32(transfer) shl 5) or (cuint32(matrix) shl 0)
+end;
+
+function SDL_COLORSPACETYPE(cspace: TSDL_Colorspace): TSDL_ColorType;
+begin
+  Result := (TSDL_ColorType(cspace) shr 28) and $0F
+end;
+
+function SDL_COLORSPACERANGE(cspace: TSDL_Colorspace): TSDL_ColorRange;
+begin
+  Result := (TSDL_ColorRange(cspace) shr 24) and $0F
+end;
+
+function SDL_COLORSPACECHROMA(cspace: TSDL_Colorspace): TSDL_ChromaLocation;
+begin
+  Result := (TSDL_ChromaLocation(cspace) shr 20) and $0F
+end;
+
+function SDL_COLORSPACEPRIMARIES(cspace: TSDL_Colorspace): TSDL_ColorPrimaries;
+begin
+  Result := (TSDL_ColorPrimaries(cspace) shr 10) and $1F
+end;
+
+function SDL_COLORSPACETRANSFER(cspace: TSDL_Colorspace): TSDL_TransferCharacteristics;
+begin
+  Result := (TSDL_TransferCharacteristics(cspace) shr 5) and $1F
+end;
+
+function SDL_COLORSPACEMATRIX(cspace: TSDL_Colorspace): TSDL_MatrixCoefficients;
+begin
+  Result := TSDL_MatrixCoefficients(cspace) and $1F
+end;
+
+function SDL_ISCOLORSPACE_MATRIX_BT601(cspace: TSDL_Colorspace): Boolean;
+begin
+  Result := (SDL_COLORSPACEMATRIX(cspace) = SDL_MATRIX_COEFFICIENTS_BT601) or (SDL_COLORSPACEMATRIX(cspace) = SDL_MATRIX_COEFFICIENTS_BT470BG)
+end;
+
+function SDL_ISCOLORSPACE_MATRIX_BT709(cspace: TSDL_Colorspace): Boolean;
+begin
+  Result := SDL_COLORSPACEMATRIX(cspace) = SDL_MATRIX_COEFFICIENTS_BT709
+end;
+
+function SDL_ISCOLORSPACE_MATRIX_BT2020_NCL(cspace: TSDL_Colorspace): Boolean;
+begin
+  Result := SDL_COLORSPACEMATRIX(cspace) = SDL_MATRIX_COEFFICIENTS_BT2020_NCL
+end;
+
+function SDL_ISCOLORSPACE_LIMITED_RANGE(cspace: TSDL_Colorspace): Boolean;
+begin
+  Result := SDL_COLORSPACERANGE(cspace) <> SDL_COLOR_RANGE_FULL
+end;
+
+function SDL_ISCOLORSPACE_FULL_RANGE(cspace: TSDL_Colorspace): Boolean;
+begin
+  Result := SDL_COLORSPACERANGE(cspace) = SDL_COLOR_RANGE_FULL
+end;
+
 end.

--- a/units/SDL_mouse.inc
+++ b/units/SDL_mouse.inc
@@ -145,6 +145,8 @@ type
   PSDL_MouseButtonFlags = ^TSDL_MouseButtonFlags;
   TSDL_MouseButtonFlags = type cuint32;
 
+function SDL_BUTTON_MASK(X: TSDL_MouseButtonFlags): TSDL_MouseButtonFlags;
+
 const
   SDL_BUTTON_LEFT  = TSDL_MouseButtonFlags(1);
   SDL_BUTTON_MIDDLE  = TSDL_MouseButtonFlags(2);
@@ -152,9 +154,8 @@ const
   SDL_BUTTON_X1  = TSDL_MouseButtonFlags(4);
   SDL_BUTTON_X2  = TSDL_MouseButtonFlags(5);
 
-  {SDL3-for-Pascal: The C macro SDL_BUTTON_MASK is not implemented but the mask
-                    defines are directly translated. }
-  {#define SDL_BUTTON_MASK(X)   (1u << ((X)-1))  }
+  {SDL3-for-Pascal: FPC does not allow assigning function results to consts,
+                    so these values are calculated manually. }
   SDL_BUTTON_LMASK  = TSDL_MouseButtonFlags(1 shl SDL_BUTTON_LEFT-1);    { SDL_BUTTON_MASK(SDL_BUTTON_LEFT)  }
   SDL_BUTTON_MMASK  = TSDL_MouseButtonFlags(1 shl SDL_BUTTON_MIDDLE-1);  { SDL_BUTTON_MASK(SDL_BUTTON_MIDDLE)  }
   SDL_BUTTON_RMASK  = TSDL_MouseButtonFlags(1 shl SDL_BUTTON_RIGHT-1);   { SDL_BUTTON_MASK(SDL_BUTTON_RIGHT)  }

--- a/units/SDL_pixels.inc
+++ b/units/SDL_pixels.inc
@@ -723,180 +723,7 @@ const
   SDL_CHROMA_LOCATION_CENTER = TSDL_ChromaLocation(2);     {*< In JPEG/JFIF, H.261, and MPEG-1, Cb and Cr are taken at the center of the 2x2 square. In other words, they are offset one-half pixel to the right and one-half pixel down compared to the top-left pixel.  }
   SDL_CHROMA_LOCATION_TOPLEFT = TSDL_ChromaLocation(3);    {*< In HEVC for BT.2020 and BT.2100 content (in particular on Blu-rays), Cb and Cr are sampled at the same location as the group's top-left Y pixel ("co-sited", "co-located").  }
 
-{ #todo : SDL3-for-Pascal: Translate these macros. }
 { Colorspace definition  }
-{
-/**
- * A macro for defining custom SDL_Colorspace formats.
- *
- * For example, defining SDL_COLORSPACE_SRGB looks like this:
- *
- * ```c
- * SDL_DEFINE_COLORSPACE(SDL_COLOR_TYPE_RGB,
- *                       SDL_COLOR_RANGE_FULL,
- *                       SDL_COLOR_PRIMARIES_BT709,
- *                       SDL_TRANSFER_CHARACTERISTICS_SRGB,
- *                       SDL_MATRIX_COEFFICIENTS_IDENTITY,
- *                       SDL_CHROMA_LOCATION_NONE)
- * ```
- *
- * \param type the type of the new format, probably an SDL_ColorType value.
- * \param range the range of the new format, probably a SDL_ColorRange value.
- * \param primaries the primaries of the new format, probably an
- *                  SDL_ColorPrimaries value.
- * \param transfer the transfer characteristics of the new format, probably an
- *                 SDL_TransferCharacteristics value.
- * \param matrix the matrix coefficients of the new format, probably an
- *               SDL_MatrixCoefficients value.
- * \param chroma the chroma sample location of the new format, probably an
- *               SDL_ChromaLocation value.
- * \returns a format value in the style of SDL_Colorspace.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_DEFINE_COLORSPACE(type, range, primaries, transfer, matrix, chroma) \
-    (((Uint32)(type) << 28) | ((Uint32)(range) << 24) | ((Uint32)(chroma) << 20) | \
-    ((Uint32)(primaries) << 10) | ((Uint32)(transfer) << 5) | ((Uint32)(matrix) << 0))
-
-/**
- * A macro to retrieve the type of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_ColorType for `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACETYPE(cspace)       (SDL_ColorType)(((cspace) >> 28) & 0x0F)
-
-/**
- * A macro to retrieve the range of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_ColorRange of `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACERANGE(cspace)      (SDL_ColorRange)(((cspace) >> 24) & 0x0F)
-
-/**
- * A macro to retrieve the chroma sample location of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_ChromaLocation of `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACECHROMA(cspace)     (SDL_ChromaLocation)(((cspace) >> 20) & 0x0F)
-
-/**
- * A macro to retrieve the primaries of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_ColorPrimaries of `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACEPRIMARIES(cspace)  (SDL_ColorPrimaries)(((cspace) >> 10) & 0x1F)
-
-/**
- * A macro to retrieve the transfer characteristics of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_TransferCharacteristics of `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACETRANSFER(cspace)   (SDL_TransferCharacteristics)(((cspace) >> 5) & 0x1F)
-
-/**
- * A macro to retrieve the matrix coefficients of an SDL_Colorspace.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns the SDL_MatrixCoefficients of `cspace`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_COLORSPACEMATRIX(cspace)     (SDL_MatrixCoefficients)((cspace) & 0x1F)
-
-/**
- * A macro to determine if an SDL_Colorspace uses BT601 (or BT470BG) matrix
- * coefficients.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns true if BT601 or BT470BG, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISCOLORSPACE_MATRIX_BT601(cspace)        (SDL_COLORSPACEMATRIX(cspace) == SDL_MATRIX_COEFFICIENTS_BT601 || SDL_COLORSPACEMATRIX(cspace) == SDL_MATRIX_COEFFICIENTS_BT470BG)
-
-/**
- * A macro to determine if an SDL_Colorspace uses BT709 matrix coefficients.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns true if BT709, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISCOLORSPACE_MATRIX_BT709(cspace)        (SDL_COLORSPACEMATRIX(cspace) == SDL_MATRIX_COEFFICIENTS_BT709)
-
-/**
- * A macro to determine if an SDL_Colorspace uses BT2020_NCL matrix
- * coefficients.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns true if BT2020_NCL, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISCOLORSPACE_MATRIX_BT2020_NCL(cspace)   (SDL_COLORSPACEMATRIX(cspace) == SDL_MATRIX_COEFFICIENTS_BT2020_NCL)
-
-/**
- * A macro to determine if an SDL_Colorspace has a limited range.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns true if limited range, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISCOLORSPACE_LIMITED_RANGE(cspace)       (SDL_COLORSPACERANGE(cspace) != SDL_COLOR_RANGE_FULL)
-
-/**
- * A macro to determine if an SDL_Colorspace has a full range.
- *
- * \param cspace an SDL_Colorspace to check.
- * \returns true if full range, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISCOLORSPACE_FULL_RANGE(cspace)          (SDL_COLORSPACERANGE(cspace) == SDL_COLOR_RANGE_FULL)
-}
 
 {*
  * Colorspace definitions.
@@ -1005,6 +832,182 @@ const
 
   SDL_COLORSPACE_RGB_DEFAULT = TSDL_Colorspace(SDL_COLORSPACE_SRGB);   {*< The default colorspace for RGB surfaces if no colorspace is specified  }
   SDL_COLORSPACE_YUV_DEFAULT = TSDL_Colorspace(SDL_COLORSPACE_BT601_LIMITED);   {*< The default colorspace for YUV surfaces if no colorspace is specified  }
+
+{**
+ * A macro for defining custom SDL_Colorspace formats.
+ *
+ * For example, defining SDL_COLORSPACE_SRGB looks like this:
+ *
+ * ```c
+ * SDL_DEFINE_COLORSPACE(SDL_COLOR_TYPE_RGB,
+ *                       SDL_COLOR_RANGE_FULL,
+ *                       SDL_COLOR_PRIMARIES_BT709,
+ *                       SDL_TRANSFER_CHARACTERISTICS_SRGB,
+ *                       SDL_MATRIX_COEFFICIENTS_IDENTITY,
+ *                       SDL_CHROMA_LOCATION_NONE)
+ * ```
+ *
+ * \param type the type of the new format, probably an SDL_ColorType value.
+ * \param range the range of the new format, probably a SDL_ColorRange value.
+ * \param primaries the primaries of the new format, probably an
+ *                  SDL_ColorPrimaries value.
+ * \param transfer the transfer characteristics of the new format, probably an
+ *                 SDL_TransferCharacteristics value.
+ * \param matrix the matrix coefficients of the new format, probably an
+ *               SDL_MatrixCoefficients value.
+ * \param chroma the chroma sample location of the new format, probably an
+ *               SDL_ChromaLocation value.
+ * \returns a format value in the style of SDL_Colorspace.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_DEFINE_COLORSPACE(
+  type_: TSDL_ColorType;
+  range: TSDL_ColorRange;
+  primaries: TSDL_ColorPrimaries;
+  transfer: TSDL_TransferCharacteristics;
+  matrix: TSDL_MatrixCoefficients;
+  chroma: TSDL_ChromaLocation
+): TSDL_Colorspace;
+
+{**
+ * A macro to retrieve the type of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_ColorType for `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACETYPE(cspace: TSDL_Colorspace): TSDL_ColorType;
+
+{**
+ * A macro to retrieve the range of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_ColorRange of `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACERANGE(cspace: TSDL_Colorspace): TSDL_ColorRange;
+
+{**
+ * A macro to retrieve the chroma sample location of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_ChromaLocation of `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACECHROMA(cspace: TSDL_Colorspace): TSDL_ChromaLocation;
+
+{**
+ * A macro to retrieve the primaries of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_ColorPrimaries of `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACEPRIMARIES(cspace: TSDL_Colorspace): TSDL_ColorPrimaries;
+
+{**
+ * A macro to retrieve the transfer characteristics of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_TransferCharacteristics of `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACETRANSFER(cspace: TSDL_Colorspace): TSDL_TransferCharacteristics;
+
+{**
+ * A macro to retrieve the matrix coefficients of an SDL_Colorspace.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns the SDL_MatrixCoefficients of `cspace`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_COLORSPACEMATRIX(cspace: TSDL_Colorspace): TSDL_MatrixCoefficients;
+
+{**
+ * A macro to determine if an SDL_Colorspace uses BT601 (or BT470BG) matrix
+ * coefficients.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns true if BT601 or BT470BG, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISCOLORSPACE_MATRIX_BT601(cspace: TSDL_Colorspace): Boolean;
+
+{**
+ * A macro to determine if an SDL_Colorspace uses BT709 matrix coefficients.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns true if BT709, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISCOLORSPACE_MATRIX_BT709(cspace: TSDL_Colorspace): Boolean;
+
+{**
+ * A macro to determine if an SDL_Colorspace uses BT2020_NCL matrix
+ * coefficients.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns true if BT2020_NCL, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISCOLORSPACE_MATRIX_BT2020_NCL(cspace: TSDL_Colorspace): Boolean;
+
+{**
+ * A macro to determine if an SDL_Colorspace has a limited range.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns true if limited range, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISCOLORSPACE_LIMITED_RANGE(cspace: TSDL_Colorspace): Boolean;
+
+{**
+ * A macro to determine if an SDL_Colorspace has a full range.
+ *
+ * \param cspace an SDL_Colorspace to check.
+ * \returns true if full range, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISCOLORSPACE_FULL_RANGE(cspace: TSDL_Colorspace): Boolean;
 
 {*
 * A structure that represents a color as RGBA components.

--- a/units/SDL_pixels.inc
+++ b/units/SDL_pixels.inc
@@ -193,303 +193,6 @@ const
   SDL_PACKEDLAYOUT_2101010 = TSDL_PackedLayout(7);
   SDL_PACKEDLAYOUT_1010102 = TSDL_PackedLayout(8);
 
-{ #todo : SDL3-for-Pascal: Translate these macros. }
-{
-/**
- * A macro for defining custom FourCC pixel formats.
- *
- * For example, defining SDL_PIXELFORMAT_YV12 looks like this:
- *
- * ```c
- * SDL_DEFINE_PIXELFOURCC('Y', 'V', '1', '2')
- * ```
- *
- * \param A the first character of the FourCC code.
- * \param B the second character of the FourCC code.
- * \param C the third character of the FourCC code.
- * \param D the fourth character of the FourCC code.
- * \returns a format value in the style of SDL_PixelFormat.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_DEFINE_PIXELFOURCC(A, B, C, D) SDL_FOURCC(A, B, C, D)
-
-/**
- * A macro for defining custom non-FourCC pixel formats.
- *
- * For example, defining SDL_PIXELFORMAT_RGBA8888 looks like this:
- *
- * ```c
- * SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_8888, 32, 4)
- * ```
- *
- * \param type the type of the new format, probably a SDL_PixelType value.
- * \param order the order of the new format, probably a SDL_BitmapOrder,
- *              SDL_PackedOrder, or SDL_ArrayOrder value.
- * \param layout the layout of the new format, probably an SDL_PackedLayout
- *               value or zero.
- * \param bits the number of bits per pixel of the new format.
- * \param bytes the number of bytes per pixel of the new format.
- * \returns a format value in the style of SDL_PixelFormat.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_DEFINE_PIXELFORMAT(type, order, layout, bits, bytes) \
-    ((1 << 28) | ((type) << 24) | ((order) << 20) | ((layout) << 16) | \
-     ((bits) << 8) | ((bytes) << 0))
-
-/**
- * A macro to retrieve the flags of an SDL_PixelFormat.
- *
- * This macro is generally not needed directly by an app, which should use
- * specific tests, like SDL_ISPIXELFORMAT_FOURCC, instead.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the flags of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_PIXELFLAG(format)    (((format) >> 28) & 0x0F)
-
-/**
- * A macro to retrieve the type of an SDL_PixelFormat.
- *
- * This is usually a value from the SDL_PixelType enumeration.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the type of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_PIXELTYPE(format)    (((format) >> 24) & 0x0F)
-
-/**
- * A macro to retrieve the order of an SDL_PixelFormat.
- *
- * This is usually a value from the SDL_BitmapOrder, SDL_PackedOrder, or
- * SDL_ArrayOrder enumerations, depending on the format type.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the order of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_PIXELORDER(format)   (((format) >> 20) & 0x0F)
-
-/**
- * A macro to retrieve the layout of an SDL_PixelFormat.
- *
- * This is usually a value from the SDL_PackedLayout enumeration, or zero if a
- * layout doesn't make sense for the format type.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the layout of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_PIXELLAYOUT(format)  (((format) >> 16) & 0x0F)
-
-/**
- * A macro to determine an SDL_PixelFormat's bits per pixel.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * FourCC formats will report zero here, as it rarely makes sense to measure
- * them per-pixel.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the bits-per-pixel of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- *
- * \sa SDL_BYTESPERPIXEL
- */
-#define SDL_BITSPERPIXEL(format) \
-    (SDL_ISPIXELFORMAT_FOURCC(format) ? 0 : (((format) >> 8) & 0xFF))
-
-/**
- * A macro to determine an SDL_PixelFormat's bytes per pixel.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * FourCC formats do their best here, but many of them don't have a meaningful
- * measurement of bytes per pixel.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns the bytes-per-pixel of `format`.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- *
- * \sa SDL_BITSPERPIXEL
- */
-#define SDL_BYTESPERPIXEL(format) \
-    (SDL_ISPIXELFORMAT_FOURCC(format) ? \
-        ((((format) == SDL_PIXELFORMAT_YUY2) || \
-          ((format) == SDL_PIXELFORMAT_UYVY) || \
-          ((format) == SDL_PIXELFORMAT_YVYU) || \
-          ((format) == SDL_PIXELFORMAT_P010)) ? 2 : 1) : (((format) >> 0) & 0xFF))
-
-
-/**
- * A macro to determine if an SDL_PixelFormat is an indexed format.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format is indexed, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_INDEXED(format)   \
-    (!SDL_ISPIXELFORMAT_FOURCC(format) && \
-     ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_INDEX1) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_INDEX2) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_INDEX4) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_INDEX8)))
-
-/**
- * A macro to determine if an SDL_PixelFormat is a packed format.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format is packed, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_PACKED(format) \
-    (!SDL_ISPIXELFORMAT_FOURCC(format) && \
-     ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_PACKED8) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_PACKED16) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_PACKED32)))
-
-/**
- * A macro to determine if an SDL_PixelFormat is an array format.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format is an array, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_ARRAY(format) \
-    (!SDL_ISPIXELFORMAT_FOURCC(format) && \
-     ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYU8) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYU16) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYU32) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYF16) || \
-      (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYF32)))
-
-/**
- * A macro to determine if an SDL_PixelFormat is a 10-bit format.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format is 10-bit, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_10BIT(format)    \
-      (!SDL_ISPIXELFORMAT_FOURCC(format) && \
-       ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_PACKED32) && \
-        (SDL_PIXELLAYOUT(format) == SDL_PACKEDLAYOUT_2101010)))
-
-/**
- * A macro to determine if an SDL_PixelFormat is a floating point format.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format is a floating point, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_FLOAT(format)    \
-      (!SDL_ISPIXELFORMAT_FOURCC(format) && \
-       ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYF16) || \
-        (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYF32)))
-
-/**
- * A macro to determine if an SDL_PixelFormat has an alpha channel.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format has alpha, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_ALPHA(format)   \
-    ((SDL_ISPIXELFORMAT_PACKED(format) && \
-      ((SDL_PIXELORDER(format) == SDL_PACKEDORDER_ARGB) || \
-       (SDL_PIXELORDER(format) == SDL_PACKEDORDER_RGBA) || \
-       (SDL_PIXELORDER(format) == SDL_PACKEDORDER_ABGR) || \
-       (SDL_PIXELORDER(format) == SDL_PACKEDORDER_BGRA))) || \
-     (SDL_ISPIXELFORMAT_ARRAY(format) && \
-      ((SDL_PIXELORDER(format) == SDL_ARRAYORDER_ARGB) || \
-       (SDL_PIXELORDER(format) == SDL_ARRAYORDER_RGBA) || \
-       (SDL_PIXELORDER(format) == SDL_ARRAYORDER_ABGR) || \
-       (SDL_PIXELORDER(format) == SDL_ARRAYORDER_BGRA))))
-
-
-
-/**
- * A macro to determine if an SDL_PixelFormat is a "FourCC" format.
- *
- * This covers custom and other unusual formats.
- *
- * Note that this macro double-evaluates its parameter, so do not use
- * expressions with side-effects here.
- *
- * \param format an SDL_PixelFormat to check.
- * \returns true if the format has alpha, false otherwise.
- *
- * \threadsafety It is safe to call this macro from any thread.
- *
- * \since This macro is available since SDL 3.2.0.
- */
-#define SDL_ISPIXELFORMAT_FOURCC(format)  /* The flag is set to 1 because 0x1? is not in the printable ASCII range */ \
-    ((format) && (SDL_PIXELFLAG(format) != 1))
-}
-
 { Note: If you modify this enum, update SDL_GetPixelFormatName()  }
 
 {*
@@ -637,6 +340,258 @@ const
       {$FATAL Cannot determine endianness.}
     {$IFEND}
   {$ENDIF}
+
+{*
+ * A macro for defining custom FourCC pixel formats.
+ *
+ * For example, defining SDL_PIXELFORMAT_YV12 looks like this:
+ *
+ * ```c
+ * SDL_DEFINE_PIXELFOURCC('Y', 'V', '1', '2')
+ * ```
+ *
+ * \param A the first character of the FourCC code.
+ * \param B the second character of the FourCC code.
+ * \param C the third character of the FourCC code.
+ * \param D the fourth character of the FourCC code.
+ * \returns a format value in the style of SDL_PixelFormat.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_DEFINE_PIXELFOURCC(A, B, C, D: AnsiChar): TSDL_PixelFormat;
+
+{*
+ * A macro for defining custom non-FourCC pixel formats.
+ *
+ * For example, defining SDL_PIXELFORMAT_RGBA8888 looks like this:
+ *
+ * ```c
+ * SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_8888, 32, 4)
+ * ```
+ *
+ * \param type the type of the new format, probably a SDL_PixelType value.
+ * \param order the order of the new format, probably a SDL_BitmapOrder,
+ *              SDL_PackedOrder, or SDL_ArrayOrder value.
+ * \param layout the layout of the new format, probably an SDL_PackedLayout
+ *               value or zero.
+ * \param bits the number of bits per pixel of the new format.
+ * \param bytes the number of bytes per pixel of the new format.
+ * \returns a format value in the style of SDL_PixelFormat.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_DEFINE_PIXELFORMAT(type_: TSDL_PixelType; order: Integer; layout: TSDL_PackedLayout; bits, bytes: Integer): TSDL_PixelFormat;
+
+{*
+ * A macro to retrieve the flags of an SDL_PixelFormat.
+ *
+ * This macro is generally not needed directly by an app, which should use
+ * specific tests, like SDL_ISPIXELFORMAT_FOURCC, instead.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the flags of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_PIXELFLAG(format: TSDL_PixelFormat): Integer;
+
+{*
+ * A macro to retrieve the type of an SDL_PixelFormat.
+ *
+ * This is usually a value from the SDL_PixelType enumeration.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the type of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_PIXELTYPE(format: TSDL_PixelFormat): TSDL_PixelType;
+
+{*
+ * A macro to retrieve the order of an SDL_PixelFormat.
+ *
+ * This is usually a value from the SDL_BitmapOrder, SDL_PackedOrder, or
+ * SDL_ArrayOrder enumerations, depending on the format type.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the order of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_PIXELORDER(format: TSDL_PixelFormat): Integer;
+
+{*
+ * A macro to retrieve the layout of an SDL_PixelFormat.
+ *
+ * This is usually a value from the SDL_PackedLayout enumeration, or zero if a
+ * layout doesn't make sense for the format type.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the layout of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_PIXELLAYOUT(format: TSDL_PixelFormat): TSDL_PackedLayout;
+
+{**
+ * A macro to determine an SDL_PixelFormat's bits per pixel.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * FourCC formats will report zero here, as it rarely makes sense to measure
+ * them per-pixel.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the bits-per-pixel of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *
+ * \sa SDL_BYTESPERPIXEL
+ *}
+function SDL_BITSPERPIXEL(format: TSDL_PixelFormat): Integer;
+
+{**
+ * A macro to determine an SDL_PixelFormat's bytes per pixel.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * FourCC formats do their best here, but many of them don't have a meaningful
+ * measurement of bytes per pixel.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns the bytes-per-pixel of `format`.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *
+ * \sa SDL_BITSPERPIXEL
+ *}
+function SDL_BYTESPERPIXEL(format: TSDL_PixelFormat): Integer;
+
+{**
+ * A macro to determine if an SDL_PixelFormat is an indexed format.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format is indexed, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_INDEXED(format: TSDL_PixelFormat): Boolean;
+
+{*
+ * A macro to determine if an SDL_PixelFormat is a packed format.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format is packed, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_PACKED(format: TSDL_PixelFormat): Boolean;
+
+{**
+ * A macro to determine if an SDL_PixelFormat is an array format.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format is an array, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_ARRAY(format: TSDL_PixelFormat): Boolean;
+
+{**
+ * A macro to determine if an SDL_PixelFormat is a 10-bit format.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format is 10-bit, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_10BIT(format: TSDL_PixelFormat): Boolean;
+
+{**
+ * A macro to determine if an SDL_PixelFormat is a floating point format.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format is a floating point, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_FLOAT(format: TSDL_PixelFormat): Boolean;
+
+{**
+ * A macro to determine if an SDL_PixelFormat has an alpha channel.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format has alpha, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_ALPHA(format: TSDL_PixelFormat): Boolean;
+
+{**
+ * A macro to determine if an SDL_PixelFormat is a "FourCC" format.
+ *
+ * This covers custom and other unusual formats.
+ *
+ * Note that this macro double-evaluates its parameter, so do not use
+ * expressions with side-effects here.
+ *
+ * \param format an SDL_PixelFormat to check.
+ * \returns true if the format has alpha, false otherwise.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_ISPIXELFORMAT_FOURCC(format: TSDL_PixelFormat): Boolean;
+
 
 {*
  * Colorspace color type.

--- a/units/SDL_stdinc.inc
+++ b/units/SDL_stdinc.inc
@@ -7,6 +7,22 @@
 }
 
 {*
+ * Define a four character code as a Uint32.
+ *
+ * \param A the first ASCII character.
+ * \param B the second ASCII character.
+ * \param C the third ASCII character.
+ * \param D the fourth ASCII character.
+ * \returns the four characters converted into a Uint32, one character
+ *          per-byte.
+ *
+ * \threadsafety It is safe to call this macro from any thread.
+ *
+ * \since This macro is available since SDL 3.2.0.
+ *}
+function SDL_FOURCC(A, B, C, D: AnsiChar): cuint32;
+
+{*
  * A signed 8-bit integer type.
  *
  * \since This macro is available since SDL 3.2.0.


### PR DESCRIPTION
`TSDL_PixelFormat` and `TSDL_Colorspace` definitions had to be moved to avoid the compiler complaining about unknown types in function arguments/return values.